### PR TITLE
feature/SS2-init-database

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,9 +23,11 @@
   "dependencies": {
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
+    "@nestjs/mongoose": "^9.0.1",
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/swagger": "^5.1.4",
     "fastify-swagger": "^4.12.6",
+    "mongoose": "^6.0.12",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.4.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { NotificationsModule } from './notifications/notifications.module';
+import { SettingsModule } from './settings/settings.module';
+
 
 @Module({
-  imports: [NotificationsModule],
+  imports: [SettingsModule,
+  MongooseModule.forRoot('mongodb://127.0.0.1:27017/SmokerDB')],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/settings/settings.controller.ts
+++ b/backend/src/settings/settings.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Settings } from './settings.schema';
+import { SettingsService } from './settings.service';
+import { CreateSettingsDto } from './settingsDto';
+
+@ApiTags('settings')
+@Controller('api/settings')
+export class SettingsController {
+    constructor(private readonly settingsService: SettingsService){}
+    
+    @Get()
+    getSettings(): Promise<Settings[]> {
+        return this.settingsService.findAll();
+    }
+
+    @Post()
+    SetSettings(@Body() dto: CreateSettingsDto): Promise<Settings> {
+        return this.settingsService.create(dto);
+    }
+}

--- a/backend/src/settings/settings.module.ts
+++ b/backend/src/settings/settings.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { SettingsController } from './settings.controller';
+import { SettingsService } from './settings.service';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Settings, SettingsSchema } from './settings.schema';
+
+
+@Module({
+  imports: [MongooseModule.forFeature([{name: Settings.name, schema: SettingsSchema}])],
+  controllers: [SettingsController],
+  providers: [SettingsService],
+})
+export class SettingsModule {}

--- a/backend/src/settings/settings.schema.ts
+++ b/backend/src/settings/settings.schema.ts
@@ -1,0 +1,35 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose'
+
+export type NotificationsDocument = Notifications & Document;
+
+@Schema()
+export class Notifications {
+    @Prop()
+    MinMeatTemp: number;
+    @Prop()
+    MaxMeatTemp: number;
+    @Prop()
+    MinChamberTemp: number;
+    @Prop()
+    MaxChamberTemp: number;
+}
+
+export const NotificationsSchema = SchemaFactory.createForClass(Notifications);
+export type SettingsDocument = Settings & Document
+
+
+@Schema()
+export class Settings {
+    @Prop()
+    id: string;
+
+    @Prop()
+    dataExportEmail: string;
+
+    @Prop()
+    notifications: Notifications;
+}
+
+export const SettingsSchema = SchemaFactory.createForClass(Settings);
+

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Settings, SettingsDocument } from './settings.schema';
+import { Model } from 'mongoose';
+import { CreateSettingsDto } from './settingsDto';
+
+@Injectable()
+export class SettingsService {
+    constructor(@InjectModel(Settings.name)private settingsModel: Model<SettingsDocument>){}
+
+    async create(createSettingsDto: CreateSettingsDto): Promise<Settings>{
+        const createdSettings = new this.settingsModel(createSettingsDto);
+        return createdSettings.save();
+    }
+
+    async findAll(): Promise<Settings[]> {
+        return this.settingsModel.find().exec();
+    }
+}

--- a/backend/src/settings/settingsDto.ts
+++ b/backend/src/settings/settingsDto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class Notifications {
+    @ApiProperty()
+    MinMeatTemp: number;
+    @ApiProperty()
+    MaxMeatTemp: number;
+    @ApiProperty()
+    MinChamberTemp: number;
+    @ApiProperty()
+    MaxChamberTemp: number;
+}
+
+export class CreateSettingsDto {
+    @ApiProperty()
+    id: string;
+    @ApiProperty()
+    dataExportEmail: string;
+    @ApiProperty()
+    notifications: Notifications;
+}
+


### PR DESCRIPTION
added database hook up for settings

how to test:

1. start up a local instance of mongoDB via this link [mongoDB](https://docs.mongodb.com/guides/server/install/)
2. run `npm install` inside the backend folder
3. go to `http://localhost:3000/api/` should see a get and set endpoints
4. test those endpoint, should be able to dto example in swagger