### PR TITLE
feature/infra-p1-s2-manual-version-deploy

### DIFF
--- a/.github/workflows/deploy-version.yml
+++ b/.github/workflows/deploy-version.yml
@@ -1,0 +1,56 @@
+# Manual deploy of a specific version to cloud and/or smoker
+
+name: Deploy Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 1.2.3, v1.2.3, or nightly)'
+        type: string
+        required: true
+      deploy_cloud:
+        description: 'Deploy to cloud'
+        type: boolean
+        required: false
+        default: true
+      deploy_smoker:
+        description: 'Deploy to smoker devices'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.norm.outputs.version }}
+    steps:
+      - name: Normalize version
+        id: norm
+        shell: bash
+        run: |
+          IN="${{ github.event.inputs.version }}"
+          if [[ "$IN" == "nightly" ]]; then
+            OUT="nightly"
+          elif [[ "$IN" == v* ]]; then
+            OUT="$IN"
+          else
+            OUT="v$IN"
+          fi
+          echo "Normalized: $OUT"
+          echo "version=$OUT" >> "$GITHUB_OUTPUT"
+
+  deploy-cloud:
+    if: ${{ github.event.inputs.deploy_cloud == 'true' }}
+    needs: set-version
+    uses: ./.github/workflows/cloud-deploy.yml
+    with:
+      version: ${{ needs.set-version.outputs.version }}
+    secrets: inherit
+
+  deploy-smoker:
+    if: ${{ github.event.inputs.deploy_smoker == 'true' }}
+    uses: ./.github/workflows/smoker-deploy.yml
+    secrets: inherit
+

--- a/.github/workflows/deploy-version.yml
+++ b/.github/workflows/deploy-version.yml
@@ -20,6 +20,13 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-version
+  cancel-in-progress: true
+
 jobs:
   set-version:
     runs-on: ubuntu-latest
@@ -31,7 +38,10 @@ jobs:
         shell: bash
         run: |
           IN="${{ github.event.inputs.version }}"
-          if [[ "$IN" == "nightly" ]]; then
+          # Trim whitespace, normalize leading V to v, and support case-insensitive nightly
+          IN="$(echo "$IN" | xargs)"
+          IN="${IN/#V/v}"
+          if [[ "${IN,,}" == "nightly" ]]; then
             OUT="nightly"
           elif [[ "$IN" == v* ]]; then
             OUT="$IN"
@@ -53,4 +63,3 @@ jobs:
     if: ${{ github.event.inputs.deploy_smoker == 'true' }}
     uses: ./.github/workflows/smoker-deploy.yml
     secrets: inherit
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Normalize version/ref from workflow_dispatch input or release tag
   set-version:
@@ -47,6 +54,9 @@ jobs:
             DEPLOY_CLOUD_DEFAULT=true
           else
             IN="${{ github.event.inputs.version }}"
+            # trim whitespace and normalize leading V to v
+            IN="$(echo "$IN" | xargs)"
+            IN="${IN/#V/v}"
             NUM="${IN#v}"
             VTAG="v${NUM}"
             # Use the tag ref when a tag exists; otherwise this will checkout the branch/commit if it matches
@@ -107,6 +117,7 @@ jobs:
     if: ${{ needs.set-version.outputs.deploy_smoker_default == 'true' }}
     needs: publish-smoker
     uses: ./.github/workflows/smoker-deploy.yml
+    secrets: inherit
 
   # Deploy to cloud infrastructure (pinned to version tag)
   deploy-cloud:
@@ -115,3 +126,4 @@ jobs:
     uses: ./.github/workflows/cloud-deploy.yml
     with:
       version: ${{ needs.set-version.outputs.version_tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,11 @@
 name: Release Smart Smoker v2
 
 on:
+  # Manual release (existing behavior)
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 1.0.0)'
+        description: 'Version to release (e.g., 1.0.0 or v1.0.0)'
         type: string
         required: true
       deploy_smoker:
@@ -19,52 +20,98 @@ on:
         type: boolean
         required: false
         default: true
+  # New: auto-run on GitHub Release publish
+  release:
+    types: [published]
 
 jobs:
+  # Normalize version/ref from workflow_dispatch input or release tag
+  set-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version_numeric: ${{ steps.norm.outputs.version_numeric }}
+      version_tag: ${{ steps.norm.outputs.version_tag }}
+      ref: ${{ steps.norm.outputs.ref }}
+      deploy_smoker_default: ${{ steps.norm.outputs.deploy_smoker_default }}
+      deploy_cloud_default: ${{ steps.norm.outputs.deploy_cloud_default }}
+    steps:
+      - id: norm
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG="${{ github.event.release.tag_name }}"
+            NUM="${TAG#v}"
+            VTAG="v${NUM}"
+            REF="$VTAG"
+            DEPLOY_SMOKER_DEFAULT=true
+            DEPLOY_CLOUD_DEFAULT=true
+          else
+            IN="${{ github.event.inputs.version }}"
+            NUM="${IN#v}"
+            VTAG="v${NUM}"
+            # Use the tag ref when a tag exists; otherwise this will checkout the branch/commit if it matches
+            REF="$VTAG"
+            DEPLOY_SMOKER_DEFAULT=${{ github.event.inputs.deploy_smoker == 'true' && 'true' || 'false' }}
+            DEPLOY_CLOUD_DEFAULT=${{ github.event.inputs.deploy_cloud == 'true' && 'true' || 'false' }}
+          fi
+          echo "version_numeric=$NUM" >> "$GITHUB_OUTPUT"
+          echo "version_tag=$VTAG" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "deploy_smoker_default=$DEPLOY_SMOKER_DEFAULT" >> "$GITHUB_OUTPUT"
+          echo "deploy_cloud_default=$DEPLOY_CLOUD_DEFAULT" >> "$GITHUB_OUTPUT"
+
   # Build smoker applications (no Docker)
   build-smoker:
+    needs: set-version
     uses: ./.github/workflows/build.yml
     with:
       apps: '["smoker", "device-service", "electron-shell"]'
       mode: 'build'
-      ref: ${{ github.event.inputs.version }}
+      ref: ${{ needs.set-version.outputs.ref }}
 
   # Build cloud applications (no Docker)
   build-cloud:
+    needs: set-version
     uses: ./.github/workflows/build.yml
     with:
       apps: '["backend", "frontend"]'
       mode: 'build'
-      ref: ${{ github.event.inputs.version }}
+      ref: ${{ needs.set-version.outputs.ref }}
 
   # Build and publish smoker Docker images
   publish-smoker:
+    needs: [set-version, build-smoker]
     uses: ./.github/workflows/publish.yml
     with:
       apps: '["smoker", "device-service", "electron-shell"]'
-      version: ${{ github.event.inputs.version }}
-      ref: ${{ github.event.inputs.version }}
+      version: ${{ needs.set-version.outputs.version_numeric }}
+      ref: ${{ needs.set-version.outputs.ref }}
+      mode: 'release'
+      platforms: 'linux/amd64,linux/arm/v7'
     secrets: inherit
 
   # Build and publish cloud Docker images
   publish-cloud:
+    needs: [set-version, build-cloud]
     uses: ./.github/workflows/publish.yml
     with:
       apps: '["backend", "frontend"]'
-      version: ${{ github.event.inputs.version }}
-      ref: ${{ github.event.inputs.version }}
+      version: ${{ needs.set-version.outputs.version_numeric }}
+      ref: ${{ needs.set-version.outputs.ref }}
+      mode: 'release'
+      platforms: 'linux/amd64,linux/arm/v7'
     secrets: inherit
 
-  # Deploy to smoker devices
+  # Deploy to smoker devices (optional; Watchtower will also update :latest)
   deploy-smoker:
-    if: ${{ github.event.inputs.deploy_smoker == 'true' }}
+    if: ${{ needs.set-version.outputs.deploy_smoker_default == 'true' }}
     needs: publish-smoker
     uses: ./.github/workflows/smoker-deploy.yml
 
-  # Deploy to cloud infrastructure
+  # Deploy to cloud infrastructure (pinned to version tag)
   deploy-cloud:
-    if: ${{ github.event.inputs.deploy_cloud == 'true' }}
+    if: ${{ needs.set-version.outputs.deploy_cloud_default == 'true' }}
     needs: publish-cloud
     uses: ./.github/workflows/cloud-deploy.yml
     with:
-      version: v${{ github.event.inputs.version }}
+      version: ${{ needs.set-version.outputs.version_tag }}

--- a/docs/CI-CD/github-actions.md
+++ b/docs/CI-CD/github-actions.md
@@ -25,11 +25,13 @@ This directory contains GitHub Actions workflows for the Smart Smoker V2 project
 
 ### Other Workflows
 - `install.yml`: Installation and setup workflow
-- `build-publish-cloud.yml`: Cloud deployment build
-- `build-publish-smoker.yml`: Smoker app build
-- `cloud-deploy.yml`: Cloud environment deployment
-- `smoker-deploy.yml`: Smoker environment deployment  
+- `build.yml`: Application build validation (reusable)
+- `publish.yml`: Docker Hub publishing (reusable)
+- `cloud-deploy.yml`: Cloud environment deployment (reusable)
+- `smoker-deploy.yml`: Smoker environment deployment (reusable)  
 - `docs.yml`: Documentation deployment
+- `deploy-version.yml`: Manually deploy a specific version/tag to cloud and/or smoker
+- `release.yml`: Build, publish, and deploy. Supports manual version input and Release tag trigger
 
 ## Branch Protection
 

--- a/docs/CI-CD/index.md
+++ b/docs/CI-CD/index.md
@@ -55,6 +55,9 @@ Production deployment processes and infrastructure management:
 - **Network Configuration**: Tailscale setup and SSL management
 - **Monitoring Setup**: Portainer installation and configuration
 
+### [Manual Version Deployment](manual-version-deployment.md)
+Runbook for deploying specific container versions to the cloud using GitHub Actions or local Docker Compose, including rollback and verification steps.
+
 ## Quick Reference
 
 ### CI Pipeline Status Checks

--- a/docs/CI-CD/manual-version-deployment.md
+++ b/docs/CI-CD/manual-version-deployment.md
@@ -9,13 +9,27 @@ Deploy a specific container version to the cloud environment using Docker Compos
 - Environment values for `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY`
 - Images published in Docker Hub with version tags (e.g., `v1.2.3`)
 
-## Option A: GitHub Actions (Deploy Version)
+## Option A: GitHub Release (Preferred)
+- Workflow: `.github/workflows/release.yml` (triggered by Release → Published)
+- Tag format: `vX.Y.Z` (e.g., `v1.2.3`)
+- Behavior: Builds from the tag, publishes Docker images with both `latest` and `vX.Y.Z`, and deploys cloud pinned to `vX.Y.Z`.
+
+Steps:
+1) GitHub → Releases → “Draft a new release”
+2) Set tag to `vX.Y.Z` and publish
+3) The workflow runs automatically and deploys cloud with `VERSION=vX.Y.Z`
+
+Notes:
+- Smoker devices auto-update from `latest` via Watchtower; the release also updates `latest`.
+- Use “Deploy Version” for redeploying an existing version without rebuilding.
+
+## Option B: GitHub Actions (Deploy Version)
 - Workflow: `.github/workflows/deploy-version.yml`
 - Inputs: `version` (accepts `1.2.3`, `v1.2.3`, or `nightly`), toggles for cloud/smoker
 - Runner: Cloud uses self-hosted `SmokeCloud`; smoker uses `Smoker`
 
 Steps:
-1) Open Actions → “Deploy Version” → Run workflow
+1) Actions → “Deploy Version” → Run workflow
 2) Enter the version (`1.2.3`, `v1.2.3`, or `nightly`). The workflow normalizes to `vX.Y.Z` when needed.
 3) Select deploy targets (cloud and/or smoker)
 4) The workflow calls existing deploy jobs and executes on the target runners:
@@ -27,6 +41,7 @@ Steps:
 Notes:
 - Secrets `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` are used by the workflow
 - Ensure the target version exists in Docker Hub for both backend and frontend images
+- Smoker deploys always use `latest` images (Watchtower), so the “Deploy Version” smoker option restarts services to pull `latest`.
 
 ## Option B: Local Shell on Cloud Host
 The compose file supports a `VERSION` env var. Set it to a specific version tag to pin the deployment:

--- a/docs/CI-CD/manual-version-deployment.md
+++ b/docs/CI-CD/manual-version-deployment.md
@@ -1,0 +1,65 @@
+# Manual Version Deployment
+
+## Overview
+Deploy a specific container version to the cloud environment using Docker Compose or GitHub Actions. Images are tagged with immutable semantic versions (`vX.Y.Z`), and production deploys pin to a chosen version while development may use `nightly`.
+
+## Prerequisites
+- Docker and Docker Compose installed on the target host
+- Access to the repository (Actions runner or shell on the cloud host)
+- Environment values for `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY`
+- Images published in Docker Hub with version tags (e.g., `v1.2.3`)
+
+## Option A: GitHub Actions (Deploy Version)
+- Workflow: `.github/workflows/deploy-version.yml`
+- Inputs: `version` (accepts `1.2.3`, `v1.2.3`, or `nightly`), toggles for cloud/smoker
+- Runner: Cloud uses self-hosted `SmokeCloud`; smoker uses `Smoker`
+
+Steps:
+1) Open Actions → “Deploy Version” → Run workflow
+2) Enter the version (`1.2.3`, `v1.2.3`, or `nightly`). The workflow normalizes to `vX.Y.Z` when needed.
+3) Select deploy targets (cloud and/or smoker)
+4) The workflow calls existing deploy jobs and executes on the target runners:
+   - `docker compose -f cloud.docker-compose.yml pull`
+   - `docker compose -f cloud.docker-compose.yml build`
+   - `docker compose -f cloud.docker-compose.yml down`
+   - `docker compose -f cloud.docker-compose.yml up -d --force-recreate`
+
+Notes:
+- Secrets `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` are used by the workflow
+- Ensure the target version exists in Docker Hub for both backend and frontend images
+
+## Option B: Local Shell on Cloud Host
+The compose file supports a `VERSION` env var. Set it to a specific version tag to pin the deployment:
+
+Quick commands:
+```bash
+VERSION=v1.2.3 \
+VAPID_PUBLIC_KEY=<your_public_key> \
+VAPID_PRIVATE_KEY=<your_private_key> \
+docker compose -f cloud.docker-compose.yml pull
+
+VERSION=v1.2.3 \
+VAPID_PUBLIC_KEY=<your_public_key> \
+VAPID_PRIVATE_KEY=<your_private_key> \
+docker compose -f cloud.docker-compose.yml up -d --force-recreate
+```
+
+Note: We previously supported a helper script and mise tasks, but deployment is now standardized via GitHub Actions or direct Docker Compose commands shown above.
+
+## Rollback
+Rollback is identical to deployment—pin to a previous version tag:
+```bash
+VERSION=v1.2.2 docker compose -f cloud.docker-compose.yml up -d --force-recreate
+```
+
+## Verification
+After deployment:
+- `docker ps` shows updated containers
+- Backend reachable at configured port (default 8443)
+- Frontend reachable at configured port (default 80)
+- Check application logs for healthy startup
+
+## Related References
+- `cloud.docker-compose.yml`
+- `docs/Infrastructure/phase-1-container-standardization.md`
+- `.github/workflows/cloud-deploy.yml`

--- a/docs/Infrastructure/phase-1-container-standardization.md
+++ b/docs/Infrastructure/phase-1-container-standardization.md
@@ -106,6 +106,8 @@ Why this matters
 - Version tags never change once published
 - Clear version history in Docker Hub
 
+See: [Manual Version Deployment](../CI-CD/manual-version-deployment.md) for the deployment runbook and rollback steps.
+
 ### Story 3: Development Workflow
 **As a** developer  
 **I want** the publishing workflow to be automatic  


### PR DESCRIPTION
# PR: Build/Publish From Release Tags and Deploy Pinned Version

## Title
feat(ci): build/publish from release tags and deploy pinned version

## Summary
Implements Phase 1 — Story 2 “Manual Version Deployment”. The release workflow builds images from a Git release tag and publishes both `latest` and `vX.Y.Z`. Cloud deploys are pinned to the specific version, while smoker devices continue to auto‑update from `latest` via Watchtower. Adds an optional workflow to redeploy already‑published versions without rebuilding.

## Why
- Precise control over production versions (pin to `vX.Y.Z`).
- Rollback safety with immutable tags.
- Preserve Watchtower auto‑updates for smoker devices via `latest`.

## What Changed
- `.github/workflows/release.yml`
  - Dual trigger: `workflow_dispatch` and `release: published`.
  - Normalizes input (e.g., `1.2.3` → `v1.2.3`) and checks out the tag as the ref for reproducible builds.
  - Calls reusable `publish.yml` in `release` mode to push both `latest` and `vX.Y.Z`.
  - Multi‑arch publish: `linux/amd64,linux/arm/v7`.
  - Deploys cloud pinned to the version (`VERSION=vX.Y.Z`).
- `.github/workflows/deploy-version.yml` (optional)
  - Manual UI to redeploy existing images (no build/publish). Accepts `1.2.3`, `v1.2.3`, or `nightly`.
  - Can deploy to Cloud and/or Smoker in a single run.
- Docs
  - `docs/CI-CD/manual-version-deployment.md`: Runbook for manual, versioned deployments.
  - Linked from `docs/CI-CD/index.md` and referenced in `docs/Infrastructure/phase-1-container-standardization.md`.
- Cleanup
  - Removed references to local deploy scripts/mise tasks; deployment is Actions‑first.

## How To Use
- Preferred: GitHub Release
  1. Create a release with tag `v1.2.3` (or your version).
  2. The workflow builds from that tag, publishes `latest` and `v1.2.3`, then deploys cloud with `VERSION=v1.2.3`.
- Manual release (no GitHub Release)
  1. Actions → “Release Smart Smoker v2” → Run workflow.
  2. Enter `1.2.3` or `v1.2.3`; it normalizes to `v1.2.3` and follows the same publish+deploy steps.
- Manual redeploy (no build/publish)
  - Actions → “Deploy Version” → Enter `1.2.3`, `v1.2.3`, or `nightly` → choose Cloud/Smoker → run.

## Acceptance Criteria Coverage
- Specific version tags available: `vX.Y.Z` published for all services.
- Deploy historical versions: Cloud deploys accept `VERSION=vX.Y.Z`.
- Immutable tags: `vX.Y.Z` never overwritten (rollback friendly).
- Clear version history in Docker Hub: `latest` and `vX.Y.Z` present for each service.

## Runners & Secrets
- Runners: `SmokeCloud` (cloud deploy), `Smoker` (optional smoker deploy).
- Secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`.

## Verification
- Docker Hub shows both `latest` and `vX.Y.Z` for all images.
- Cloud containers run with `VERSION=vX.Y.Z`.
- Optional integrity check: verify `latest` and `vX.Y.Z` digests match for a release using `docker buildx imagetools inspect`.

## Backward Compatibility
- No breaking changes to existing deployment workflows.
- Optional manual redeploy can be removed later if not desired; the release flow remains authoritative.

## Follow‑Ups (Optional)
- Add a post‑publish digest parity check (ensure `latest` and `vX.Y.Z` reference the same manifest for a given release).
- Enable smoker deploy by default in release workflow if a forced restart on release is desired (Watchtower already handles `latest`).

