### PR TITLE
feat(ci): Phase 1 Story 3 — automated dev publish workflow + docs/badges cleanup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,13 @@ on:
         required: false
         default: 'master'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
 jobs:
   publish-nightly:
     uses: ./.github/workflows/publish.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Smart-Smoker-V2
 
-![Build and Publish](https://github.com/benjr70/Smart-Smoker-V2/actions/workflows/install.yml/badge.svg)
+![CI - Tests and Build Validation](https://github.com/benjr70/Smart-Smoker-V2/actions/workflows/ci-tests.yml/badge.svg)
+![Nightly Dev Build & Deploy](https://github.com/benjr70/Smart-Smoker-V2/actions/workflows/nightly.yml/badge.svg)
+![Release Smart Smoker v2](https://github.com/benjr70/Smart-Smoker-V2/actions/workflows/release.yml/badge.svg)
 ![Docs](https://github.com/benjr70/Smart-Smoker-V2/actions/workflows/docs.yml/badge.svg)<br>
 This is version 2 of smart smoker <br> All info in docs link, pls go there
 

--- a/apps/device-service/Dockerfile
+++ b/apps/device-service/Dockerfile
@@ -19,4 +19,6 @@
 
   CMD ["npm", "run", "start:prod"]
 
-  # sudo docker run --privileged  --device=/dev/ttyUSB0 -p 3000:3000 --net host -it --volume /:/host -v /var/run/dbus:/var/run/dbus  benjr70/smart_smoker:device-serviceTest
+  # sudo docker run --privileged --device=/dev/ttyUSB0 -p 3000:3000 --net host -it \
+  #   --volume /:/host -v /var/run/dbus:/var/run/dbus \
+  #   benjr70/smart-smoker-device-service:device-serviceTest

--- a/apps/smoker/shell.dockerfile
+++ b/apps/smoker/shell.dockerfile
@@ -32,7 +32,13 @@ WORKDIR /usr/local/smoker/smoker-shell-linux-armv7l
 RUN chmod +x smoker-shell
 CMD [ "./smoker-shell", "--no-sandbox" ]
 
-# sudo xhost local:root && sudo docker run --net=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY -v`pwd`/src:/app/src --rm -it --device /dev/snd benjr70/smart_smoker:electron-shell
+# sudo xhost local:root && sudo docker run --net=host \
+#   -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY \
+#   -v "$(pwd)"/src:/app/src --rm -it --device /dev/snd \
+#   benjr70/smart-smoker-electron-shell:latest
 
 
-# sudo docker run --net=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix:0 -v $(pwd)/src:/app/src --rm -it --device /dev/snd benjr70/smart_smoker:electron-shell
+# sudo docker run --net=host \
+#   -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix:0 \
+#   -v "$(pwd)"/src:/app/src --rm -it --device /dev/snd \
+#   benjr70/smart-smoker-electron-shell:latest

--- a/docs/CI-CD/deployment-infrastructure.md
+++ b/docs/CI-CD/deployment-infrastructure.md
@@ -8,7 +8,7 @@ To create a new production deployment:
 
 1. **Update version** in `package.json`
 2. **Create a version tag** in GitHub for that commit
-3. **Run the `Install Smart Smoker v2` GitHub action** with the new version number
+3. **Create a GitHub Release** with tag `vX.Y.Z` (preferred) or run the `Release Smart Smoker v2` action manually
 
 ## Container Deployment
 
@@ -103,19 +103,19 @@ To set up the smoker pi, follow the [Portainer Agent Environment instructions](h
 ```bash
 # Build for ARM/v7 platform
 docker build -f apps/smoker/Dockerfile --platform linux/arm/v7 \
-  -t benjr70/smart_smoker:smokerTest .
+  -t benjr70/smart-smoker-smoker:smokerTest .
 
 # Push to Docker Hub
-docker push benjr70/smart_smoker:smokerTest
+docker push benjr70/smart-smoker-smoker:smokerTest
 ```
 
 #### Pull and Run Smoker Image on Pi
 ```bash
 # Pull latest image
-docker pull benjr70/smart_smoker:smokerTest
+docker pull benjr70/smart-smoker-smoker:smokerTest
 
 # Run container
-docker run -p 8080:8080 benjr70/smart_smoker:smokerTest
+docker run -p 8080:8080 benjr70/smart-smoker-smoker:smokerTest
 ```
 
 ### Device Service Commands
@@ -124,20 +124,20 @@ docker run -p 8080:8080 benjr70/smart_smoker:smokerTest
 ```bash
 # Build for ARM/v7 platform
 docker build -f apps/device-service/Dockerfile --platform linux/arm/v7 \
-  -t benjr70/smart_smoker:device-serviceTest .
+  -t benjr70/smart-smoker-device-service:device-serviceTest .
 
 # Push to Docker Hub
-docker push benjr70/smart_smoker:device-serviceTest
+docker push benjr70/smart-smoker-device-service:device-serviceTest
 ```
 
 #### Pull and Run Device Service on Pi
 ```bash
 # Pull latest image
-docker pull benjr70/smart_smoker:device-serviceTest
+docker pull benjr70/smart-smoker-device-service:device-serviceTest
 
 # Run container with USB device access
 docker run --privileged --device=/dev/ttyUSB0 -p 3000:3000 \
-  benjr70/smart_smoker:device-serviceTest
+  benjr70/smart-smoker-device-service:device-serviceTest
 ```
 
 ## Architecture Overview

--- a/docs/CI-CD/github-actions.md
+++ b/docs/CI-CD/github-actions.md
@@ -30,6 +30,7 @@ This directory contains GitHub Actions workflows for the Smart Smoker V2 project
 - `cloud-deploy.yml`: Cloud environment deployment (reusable)
 - `smoker-deploy.yml`: Smoker environment deployment (reusable)  
 - `docs.yml`: Documentation deployment
+- `nightly.yml`: Nightly Dev Build & Deploy (publishes `:nightly` for testing)
 - `deploy-version.yml`: Manually deploy a specific version/tag to cloud and/or smoker
 - `release.yml`: Build, publish, and deploy. Supports manual version input and Release tag trigger
 

--- a/docs/Smoker Frontend/index.md
+++ b/docs/Smoker Frontend/index.md
@@ -20,7 +20,10 @@ dimensions for the ui is build for 800 X 400
 To build electron shell use the `npm run forge:thin` cmd to build for you arch <br>
 use the `npm run forgeLinux64:thin` to build for pi 3 that is used on smoker (results may vary base on what you are building on)
 
-To run electron docker container on pi use this cdm <br>
+To run electron docker container on Pi use this cmd <br>
 ```
-sudo xhost local:root && sudo docker run --net=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY -v`pwd`/src:/app/src --rm -it --device /dev/snd benjr70/smart_smoker:electron-shell
+sudo xhost local:root && sudo docker run --net=host \
+  -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY \
+  -v "$(pwd)"/src:/app/src --rm -it --device /dev/snd \
+  benjr70/smart-smoker-electron-shell:latest
 ```


### PR DESCRIPTION
## Summary
Completes Phase 1 — Story 3 “Development Workflow.” Automates development publishes via `:nightly`, tightens workflow settings, updates examples to the standardized image names, and refreshes README badges to reflect the current workflows.

## Why
- Automate dev publishes without manual steps.
- Keep production safe by using `:nightly` (not `:latest`).
- Ensure docs/examples consistently use `smart-smoker-*` images.
- Improve CI visibility on the README with accurate badges.

## What Changed
- Nightly workflow (safer + predictable)
  - Added least‑privilege `permissions` and `concurrency` guard to avoid overlapping runs.
  - File: `.github/workflows/nightly.yml`
- CI/CD docs
  - Added “Nightly Dev Build & Deploy” entry in the workflow overview.
  - File: `docs/CI-CD/github-actions.md`
- Image naming cleanup (smart_smoker → smart-smoker-*)
  - Updated examples and test commands across docs/comments:
  - Files:
    - `docs/CI-CD/deployment-infrastructure.md`
    - `docs/Smoker Frontend/index.md`
    - `apps/device-service/Dockerfile` (comment)
    - `apps/smoker/shell.dockerfile` (comment)
- README badges
  - Replaced outdated badge; added badges for CI Tests, Nightly, Release, Docs.
  - File: `README.md`

## How To Test
- Publish nightly images from any branch (safe):
  1. Actions → “Nightly Dev Build & Deploy” → Run workflow
  2. Set `ref` to the branch to test (e.g., `feature/infra-p1-s3-development-workflow`)
  3. Confirm `smart-smoker-<app>:nightly` images are published in Docker Hub
- Verify docs and badges:
  - README shows badges for `ci-tests.yml`, `nightly.yml`, `release.yml`, and `docs.yml`
  - Updated docs/examples reference `benjr70/smart-smoker-<service>:<tag>`

## Acceptance Criteria (Story 3)
- Automatic publishing: Nightly images built and pushed on merges to `master` (and via manual dispatch).
- No manual intervention required for development publish flow.
- Consistent container naming across docs and examples.
- Safer CI behavior: concurrency guard prevents overlapping nightly runs.

## Impact
- No production impact. Nightly only publishes `:nightly` (does not update `:latest`).
- Release process (`latest` + `vX.Y.Z`) remains unchanged.

## Rollbacks
- Revert this PR; no data migrations or infra changes.

## Notes for Reviewers
- This PR does not modify release behavior. It focuses on dev/nightly automation, documentation clarity, and README badges.

