### PR TITLE
fix: correct Tailscale Serve configuration for dev-cloud deployment

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -150,6 +150,27 @@ jobs:
           echo "Waiting for services to initialize (60 seconds)..."
           sleep 60
 
+      - name: Configure Tailscale Serve
+        run: |
+          echo "Configuring Tailscale Serve on ${DEV_HOST}..."
+          ssh root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
+            set -e
+            echo "Resetting existing Tailscale Serve configuration..."
+            tailscale serve reset || true
+            
+            echo "Configuring Tailscale Serve for frontend (port 80 -> HTTPS 443)..."
+            tailscale serve --bg 80
+            
+            echo "Configuring Tailscale Serve for backend (port 3001 -> HTTPS 8443)..."
+            tailscale serve --bg --https=8443 3001
+            
+            echo "Current Tailscale Serve configuration:"
+            tailscale serve status
+            echo "✅ Tailscale Serve configured"
+          REMOTE_SCRIPT
+        env:
+          DEV_HOST: ${{ env.DEV_HOST }}
+
       - name: Verify deployment health
         id: health_check
         run: |

--- a/infra/proxmox/ansible/inventory/host_vars/smart-smoker-dev-cloud.yml
+++ b/infra/proxmox/ansible/inventory/host_vars/smart-smoker-dev-cloud.yml
@@ -20,11 +20,11 @@ tailscale_accept_routes: true
 tailscale_accept_dns: true
 
 # Tailscale Serve - expose services on tailnet only (no public funnel)
+# https_port: The HTTPS port to expose on the tailnet (443 is default)
+# target_port: The local port to proxy traffic to
 tailscale_serve_enabled: true
 tailscale_serve_config:
-  - port: 80
+  - https_port: 443
     target_port: 80
-    protocol: http
-  - port: 3001
+  - https_port: 8443
     target_port: 3001
-    protocol: http

--- a/infra/proxmox/ansible/roles/tailscale/defaults/main.yml
+++ b/infra/proxmox/ansible/roles/tailscale/defaults/main.yml
@@ -32,17 +32,17 @@ tailscale_advertise_exit_node: false
 tailscale_advertise_routes: []
 
 # Tailscale Serve configuration
-# Enables Tailscale Serve to expose local services on the tailnet
+# Enables Tailscale Serve to expose local services on the tailnet via HTTPS
+# https_port: The HTTPS port to expose on the tailnet (443 is default)
+# target_port: The local port to proxy traffic to
 tailscale_serve_enabled: false
 tailscale_serve_config: []
 # Example:
 # tailscale_serve_config:
-#   - port: 80
-#     target_port: 80
-#     protocol: http
-#   - port: 3001
-#     target_port: 3001
-#     protocol: http
+#   - https_port: 443      # Exposes on https://hostname.ts.net/
+#     target_port: 80      # Proxies to http://localhost:80
+#   - https_port: 8443     # Exposes on https://hostname.ts.net:8443/
+#     target_port: 3001    # Proxies to http://localhost:3001
 
 # Tailscale Funnel configuration
 # Enables Tailscale Funnel to expose services publicly on the internet

--- a/infra/proxmox/ansible/roles/tailscale/tasks/serve.yml
+++ b/infra/proxmox/ansible/roles/tailscale/tasks/serve.yml
@@ -15,9 +15,8 @@
 
 - name: Configure Tailscale Serve for each port
   ansible.builtin.command: >-
-    tailscale serve
-    {% if item.protocol | default('http') == 'https' %}https{% else %}http{% endif %}:{{ item.port }}
-    /
+    tailscale serve --bg
+    {% if item.https_port | default(443) != 443 %}--https={{ item.https_port }}{% endif %}
     {{ item.target_port }}
   loop: "{{ tailscale_serve_config }}"
   register: tailscale_serve_result


### PR DESCRIPTION
# Description

Fixes the Tailscale Serve configuration that was preventing the dev-cloud frontend from being accessible via `https://smoker-dev-cloud.tail74646.ts.net/`.

## Problem

The Ansible Tailscale role was using incorrect command syntax for `tailscale serve`:
- **Old (invalid):** `tailscale serve http:80 / 80`
- **New (correct):** `tailscale serve --bg 80`

This caused Tailscale Serve to not be configured, making the dev-cloud services inaccessible via the Tailscale HTTPS URLs.

## Changes

1. **Fixed `serve.yml` Ansible task** - Updated command syntax to use correct `tailscale serve --bg` format
2. **Updated host_vars config format** - Changed from `port/protocol` to `https_port/target_port` to match Tailscale's API
3. **Updated defaults/main.yml** - Added clearer documentation and examples
4. **Added deploy workflow step** - New "Configure Tailscale Serve" step in `dev-deploy.yml` ensures serve is configured after each deployment

## Files Changed

- `.github/workflows/dev-deploy.yml` - Added Tailscale Serve configuration step
- `infra/proxmox/ansible/inventory/host_vars/smart-smoker-dev-cloud.yml` - Updated config format
- `infra/proxmox/ansible/roles/tailscale/defaults/main.yml` - Updated examples/docs
- `infra/proxmox/ansible/roles/tailscale/tasks/serve.yml` - Fixed command syntax

# Screenshots/videos

N/A - Infrastructure changes only

# Requirements

- [x] Unit tests passed (N/A - infrastructure changes)
- [x] E2E tests passed (N/A - infrastructure changes)
- [x] Coverage thresholds met (N/A - infrastructure changes)
- [x] TypeScript strict mode compliance (N/A - YAML files only)
- [x] ESLint/Prettier formatting applied (N/A - YAML files only)
- [x] No console.log in production code (N/A)
- [x] Documentation updated (defaults/main.yml comments updated)
- [ ] API documentation updated (if applicable)
- [x] Manual testing completed (Tailscale serve manually configured and verified working)
- [ ] Hardware integration tested (if applicable)
- [ ] Breaking changes documented (if applicable)