### PR TITLE
fix: resolve Docker/Tailscale port conflict on dev-cloud

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -111,6 +111,14 @@ jobs:
           scp -r infra/mongodb-init/* root@${DEV_HOST}:${DEPLOY_DIR}/infra/mongodb-init/
           echo "✅ Deployment files copied"
 
+      - name: Reset Tailscale Serve before deployment
+        run: |
+          echo "Resetting Tailscale Serve to free up ports..."
+          ssh root@${DEV_HOST} "tailscale serve reset || true"
+          echo "✅ Tailscale Serve reset"
+        env:
+          DEV_HOST: ${{ env.DEV_HOST }}
+
       - name: Deploy to dev-cloud
         id: deploy
         run: |

--- a/cloud.docker-compose.dev.yml
+++ b/cloud.docker-compose.dev.yml
@@ -20,7 +20,7 @@ services:
       - MONGO_APP_PASSWORD=${MONGO_APP_PASSWORD}
       - DB_URL=mongodb://smartsmoker:${ENCODED_MONGO_APP_PASSWORD}@mongo:27017/smartsmoker?authSource=admin
     ports:
-      - 8443:3001
+      - 127.0.0.1:3001:3001
     depends_on:
       mongo:
         condition: service_healthy
@@ -63,7 +63,7 @@ services:
     environment:
       - VAPID_PUBLIC_KEY=${VAPID_PUBLIC_KEY}
     ports:
-      - 80:3000
+      - 127.0.0.1:80:3000
     depends_on:
       backend:
         condition: service_healthy

--- a/cloud.docker-compose.yml
+++ b/cloud.docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - DB_URL=mongodb://smartsmoker:${ENCODED_MONGO_APP_PASSWORD}@mongo:27017/smartsmoker?authSource=admin
 
     ports:
-      - 8443:3001
+      - 127.0.0.1:3001:3001
 
     depends_on:
       mongo:
@@ -62,7 +62,7 @@ services:
     environment:
       - VAPID_PUBLIC_KEY=${VAPID_PUBLIC_KEY}
     ports:
-      - 80:3000
+      - 127.0.0.1:80:3000
 
     depends_on:
       backend:


### PR DESCRIPTION
# Description

Fixes the dev-deploy workflow failure caused by a port conflict between Docker and Tailscale Serve on port 8443.

## Problem

The deployment was failing with:
```
Error response from daemon: failed to bind host port for 0.0.0.0:8443:172.18.0.3:3001/tcp: address already in use
```

Both Docker (`8443:3001`) and Tailscale Serve (`--https=8443`) were trying to bind to port 8443.

## Solution

1. **Docker binds to localhost only** - External access is now exclusively via Tailscale Serve
2. **Reset Tailscale Serve before deployment** - Clears any existing config before starting containers

## Changes

### Port Binding Changes

| Service | Before | After |
|---------|--------|-------|
| Backend | `8443:3001` | `127.0.0.1:3001:3001` |
| Frontend | `80:3000` | `127.0.0.1:80:3000` |

### Traffic Flow

```
External Request (via Tailscale)
        ↓
Tailscale Serve (HTTPS termination)
  - https://smoker-dev-cloud.ts.net/ → localhost:80
  - https://smoker-dev-cloud.ts.net:8443/ → localhost:3001
        ↓
Docker Container (localhost only)
  - Frontend: 127.0.0.1:80 → container:3000
  - Backend: 127.0.0.1:3001 → container:3001
```

## Files Changed

- `cloud.docker-compose.yml` - Localhost-only port bindings
- `cloud.docker-compose.dev.yml` - Localhost-only port bindings  
- `.github/workflows/dev-deploy.yml` - Added Tailscale Serve reset step before deployment

# Screenshots/videos

N/A - Infrastructure changes only

# Requirements

- [x] Unit tests passed (N/A - infrastructure changes)
- [x] E2E tests passed (N/A - infrastructure changes)
- [x] Coverage thresholds met (N/A - infrastructure changes)
- [x] TypeScript strict mode compliance (N/A - YAML files only)
- [x] ESLint/Prettier formatting applied (N/A - YAML files only)
- [x] No console.log in production code (N/A)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] Manual testing completed
- [ ] Hardware integration tested (if applicable)
- [ ] Breaking changes documented (if applicable)