### PR TITLE
fix: use HTTPS for health checks via Tailscale Serve

### DIFF
--- a/scripts/deployment-health-check.sh
+++ b/scripts/deployment-health-check.sh
@@ -25,7 +25,8 @@ check_service() {
     echo -e "${YELLOW}Checking ${service}...${NC}"
 
     for i in $(seq 1 $retries); do
-        if curl -f -s --max-time 10 "$url" > /dev/null 2>&1; then
+        # Use -k to allow self-signed/Tailscale certificates for HTTPS
+        if curl -f -s -k --max-time 10 "$url" > /dev/null 2>&1; then
             echo -e "${GREEN}✅ ${service} is healthy${NC}"
             return 0
         fi
@@ -50,11 +51,11 @@ main() {
     echo "=========================================="
     echo ""
 
-    # Check Backend API
-    check_service "Backend API" "http://${TARGET_HOST}:8443/api/health" || exit 1
+    # Check Backend API (via Tailscale Serve HTTPS on port 8443)
+    check_service "Backend API" "https://${TARGET_HOST}:8443/api/health" || exit 1
 
-    # Check Frontend
-    check_service "Frontend" "http://${TARGET_HOST}:80" || exit 1
+    # Check Frontend (via Tailscale Serve HTTPS on port 443)
+    check_service "Frontend" "https://${TARGET_HOST}" || exit 1
 
     # Check Docker container health status (if running locally)
     if [ "${TARGET_HOST}" = "localhost" ] || [ "${TARGET_HOST}" = "127.0.0.1" ]; then


### PR DESCRIPTION
## Problem

The dev deploy workflow was failing because the health check script was using **HTTP** to connect to services exposed via Tailscale Serve, but Tailscale Serve only accepts **HTTPS** connections.

From the [failed workflow run](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/20168626124/job/57898182333):
```
Checking Backend API...
⏳ Retry 1/3 for Backend API... (waiting 10s)
⏳ Retry 2/3 for Backend API... (waiting 10s)
❌ Backend API failed health check after 3 attempts
```

The Tailscale Serve configuration uses HTTPS:
```bash
tailscale serve --bg --https=8443 3001  # Backend on HTTPS:8443
tailscale serve --bg 80                  # Frontend on HTTPS:443
```

But the health check was using HTTP:
```bash
curl http://${TARGET_HOST}:8443/api/health  # ❌ Wrong protocol
```

## Solution

- Changed Backend API health check URL from `http://` to `https://` (port 8443)
- Changed Frontend health check URL from `http://` to `https://` (port 443)
- Added `-k` flag to curl to allow Tailscale's certificates

## Testing

After this fix, the health check will correctly use HTTPS to connect to the Tailscale Serve endpoints.