### PR TITLE
fix: Add nginx proxy for API requests to resolve 405 errors

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -17,6 +17,7 @@ async function bootstrap() {
   app.enableCors({
     origin: [
       'https://smokecloud.tail74646.ts.net',
+      'https://smoker-dev-cloud.tail74646.ts.net',
       'https://smokecloud.tail74646.ts.net:8443/api',
       'http://localhost:8080',
       'http://localhost:3000',

--- a/apps/frontend/.env.prod
+++ b/apps/frontend/.env.prod
@@ -1,2 +1,1 @@
-REACT_APP_CLOUD_URL=https://smokecloud.tail74646.ts.net:8443/api/
-WS_URL=https://smokecloud.tail74646.ts.net:8443
+REACT_APP_CLOUD_URL=/api/

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -5,6 +5,17 @@ server {
     root   /usr/share/nginx/html;
     index  index.html;
 
+    # Proxy API requests to backend
+    location /api/ {
+        proxy_pass http://backend:3001/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Serve static files, fallback to index.html for SPA routing
     location / {
         try_files $uri /index.html;
     }


### PR DESCRIPTION
# Description

Fixes 405 Method Not Allowed errors on dev-cloud deployment by adding nginx proxy configuration for API requests.

## Problem
When visiting `https://smoker-dev-cloud.tail74646.ts.net/`, API requests (e.g., POST to `/presmoke`) were returning 405 errors because nginx was trying to serve static files instead of proxying requests to the backend.

## Solution
1. **Added nginx proxy configuration** - New `/api/` location block in `nginx.conf` to proxy API requests to the backend service on port 3001
2. **Updated frontend environment** - Changed `REACT_APP_CLOUD_URL` to use relative `/api/` path so requests are properly routed through nginx
3. **Added dev-cloud to CORS whitelist** - Added `https://smoker-dev-cloud.tail74646.ts.net` to backend CORS configuration for direct backend access if needed

## Changes
- `apps/frontend/nginx.conf` - Added `/api/` proxy location block
- `apps/frontend/.env.prod` - Updated `REACT_APP_CLOUD_URL` to `/api/`
- `apps/backend/src/main.ts` - Added dev-cloud URL to CORS origins

# Screenshots/videos

N/A - Infrastructure configuration change

# Requirements

- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] Coverage thresholds met
- [ ] TypeScript strict mode compliance
- [ ] ESLint/Prettier formatting applied
- [ ] No console.log in production code
- [ ] Documentation updated
- [ ] API documentation updated (if applicable)
- [ ] Manual testing completed
- [ ] Hardware integration tested (if applicable)
- [ ] Breaking changes documented (if applicable)