### PR TITLE
fix: Create .env.prod in CI before frontend build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,8 @@ jobs:
               npm run build --prefix apps/device-service
               ;;
             "frontend")
+              # Create .env.prod for frontend build (configures API path prefix)
+              echo "REACT_APP_CLOUD_URL=/api/" > apps/frontend/.env.prod
               npm run build --prefix apps/frontend
               ;;
             "smoker")


### PR DESCRIPTION
# Description

Fixes the 405 error on dev-cloud by ensuring the frontend bundle is built with the correct API path prefix.

## Problem
The previous fix added nginx proxy configuration for `/api/*` requests, but the frontend bundle was still making requests to `/presmoke` instead of `/api/presmoke` because:

1. The `.env.prod` file is gitignored
2. It doesn't exist during GitHub Actions builds
3. `REACT_APP_CLOUD_URL` was undefined during the webpack build
4. Axios used an empty baseURL, causing requests to go to the current origin without the `/api/` prefix

## Solution
Add a step in the publish workflow to create `.env.prod` with `REACT_APP_CLOUD_URL=/api/` before building the frontend.

## Changes
- `.github/workflows/publish.yml` - Create `.env.prod` file before frontend build

# Screenshots/videos

N/A - CI workflow change

# Requirements

- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] Coverage thresholds met
- [ ] TypeScript strict mode compliance
- [ ] ESLint/Prettier formatting applied
- [ ] No console.log in production code
- [ ] Documentation updated
- [ ] API documentation updated (if applicable)
- [ ] Manual testing completed
- [ ] Hardware integration tested (if applicable)
- [ ] Breaking changes documented (if applicable)