### PR TITLE
feat: Add content hash to bundle filename for cache busting

### DIFF
--- a/apps/frontend/webpack.prod.js
+++ b/apps/frontend/webpack.prod.js
@@ -12,7 +12,7 @@ module.exports = env = {
   target: 'web',
   output: {
     path: path.join(__dirname, '/dist'),
-    filename: 'bundle.js',
+    filename: 'bundle.[contenthash].js',
   },
   devtool: 'inline-source-map',
   devServer: {


### PR DESCRIPTION
# Description

Adds content hash to the webpack production bundle filename to prevent browser caching issues.

## Problem
The frontend bundle used a static filename (`bundle.js`), which caused browsers to cache old versions. When new code was deployed, users continued using the cached old bundle until they manually hard-refreshed.

This was the root cause of the 405 errors persisting after the API proxy fix was deployed - the browser was serving the old cached bundle.

## Solution
Changed `bundle.js` to `bundle.[contenthash].js` in webpack.prod.js. This generates a unique filename based on file contents (e.g., `bundle.a1b2c3d4.js`), so any code change produces a new filename that browsers will fetch fresh.

The `HtmlWebpackPlugin` automatically injects the correct hashed filename into the generated HTML.

## Changes
- `apps/frontend/webpack.prod.js` - Changed output filename to use `[contenthash]`

## Benefits
- Browsers automatically fetch new bundles when code changes
- Old bundles can be cached indefinitely (good for performance)
- No manual cache clearing required for users
- Standard webpack best practice for production builds

# Screenshots/videos

N/A - Build configuration change

# Requirements

- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] Coverage thresholds met
- [ ] TypeScript strict mode compliance
- [ ] ESLint/Prettier formatting applied
- [ ] No console.log in production code
- [ ] Documentation updated
- [ ] API documentation updated (if applicable)
- [ ] Manual testing completed
- [ ] Hardware integration tested (if applicable)
- [ ] Breaking changes documented (if applicable)