### PR TITLE
fix: Add null-safety checks to prevent backend crash when state is undefined

### DIFF
--- a/apps/backend/src/State/state.service.ts
+++ b/apps/backend/src/State/state.service.ts
@@ -21,6 +21,10 @@ export class StateService {
 
   async update(stateDto: State): Promise<State> {
     const state = await this.GetState();
+    if (!state) {
+      // Create a new state if none exists
+      return this.create(stateDto);
+    }
     return this.stateModel
       .findOneAndUpdate({ _id: state['_id'].toString() }, stateDto)
       .then(() => {
@@ -28,15 +32,12 @@ export class StateService {
       });
   }
 
-  async toggleSmoking(): Promise<State> {
+  async toggleSmoking(): Promise<State | null> {
     const state = await this.GetState();
-    if (state.smokeId.length > 0) {
-      if (state.smoking) {
-        state.smoking = false;
-      } else {
-        state.smoking = true;
-      }
+    if (!state || !state.smokeId || state.smokeId.length <= 0) {
+      return null;
     }
+    state.smoking = !state.smoking;
     return this.update(state);
   }
 

--- a/apps/backend/src/smoke/smoke.service.ts
+++ b/apps/backend/src/smoke/smoke.service.ts
@@ -38,14 +38,20 @@ export class SmokeService {
     return this.smokeModule.deleteOne({ _id: id });
   }
 
-  async getCurrentSmoke(): Promise<Smoke> {
+  async getCurrentSmoke(): Promise<Smoke | null> {
     return this.stateService.GetState().then((state) => {
+      if (!state || !state.smokeId || state.smokeId.length === 0) {
+        return null;
+      }
       return this.GetById(state.smokeId);
     });
   }
 
-  async FinishSmoke(): Promise<Smoke> {
+  async FinishSmoke(): Promise<Smoke | null> {
     return await this.getCurrentSmoke().then(async (smoke) => {
+      if (!smoke) {
+        return null;
+      }
       const smokeDto: SmokeDto = {
         smokeProfileId: smoke.smokeProfileId,
         preSmokeId: smoke.preSmokeId,

--- a/apps/backend/src/temps/temps.service.ts
+++ b/apps/backend/src/temps/temps.service.ts
@@ -17,10 +17,13 @@ export class TempsService {
 
   async saveNewTemp(tempDto: TempDto) {
     return this.stateService.GetState().then((state) => {
-      if (state.smokeId.length < 0) {
+      if (!state || !state.smokeId || state.smokeId.length <= 0) {
         return;
       }
       this.smokeService.GetById(state.smokeId).then((smoke) => {
+        if (!smoke) {
+          return;
+        }
         if (smoke.tempsId) {
           tempDto.tempsId = smoke.tempsId;
           return this.create(tempDto);
@@ -52,17 +55,16 @@ export class TempsService {
 
   async getAllTempsCurrent(): Promise<Temp[]> {
     return this.stateService.GetState().then((state) => {
-      if (state.smokeId.length > 0) {
-        return this.smokeService.GetById(state.smokeId).then((smoke) => {
-          if (smoke.tempsId && smoke.tempsId.length > 0) {
-            return this.tempModel.find({ tempsId: smoke.tempsId });
-          } else {
-            return [];
-          }
-        });
-      } else {
+      if (!state || !state.smokeId || state.smokeId.length <= 0) {
         return [];
       }
+      return this.smokeService.GetById(state.smokeId).then((smoke) => {
+        if (smoke?.tempsId && smoke.tempsId.length > 0) {
+          return this.tempModel.find({ tempsId: smoke.tempsId });
+        } else {
+          return [];
+        }
+      });
     });
   }
 
@@ -75,13 +77,13 @@ export class TempsService {
     return Temp.save();
   }
 
-  async GetTempID(): Promise<string> {
+  async GetTempID(): Promise<string | undefined> {
     return this.stateService.GetState().then((state) => {
-      if (state.smokeId.length < 0) {
+      if (!state || !state.smokeId || state.smokeId.length <= 0) {
         return undefined;
       }
       return this.smokeService.GetById(state.smokeId).then((smoke) => {
-        return smoke.tempsId;
+        return smoke?.tempsId;
       });
     });
   }


### PR DESCRIPTION
## Problem
The backend was crash-looping when the MongoDB `states` collection was empty. This occurred because several services accessed `state.smokeId` without first checking if `state` was defined.

### Error observed:
```
TypeError: Cannot read properties of undefined (reading 'smokeId')
    at /apps/backend/dist/temps/temps.service.js:87:23
```

## Root Cause
- `StateService.GetState()` returns `undefined` when the states collection is empty
- Multiple services access `state.smokeId` without null checks

## Fix
Added comprehensive null-safety checks across all affected services:

### Files Modified
- `apps/backend/src/temps/temps.service.ts` - Fixed `GetTempID`, `saveNewTemp`, `getAllTempsCurrent`
- `apps/backend/src/State/state.service.ts` - Fixed `toggleSmoking`, `update`
- `apps/backend/src/presmoke/presmoke.service.ts` - Fixed `save`, `GetByCurrent`
- `apps/backend/src/smoke/smoke.service.ts` - Fixed `getCurrentSmoke`, `FinishSmoke`
- `apps/backend/src/smokeProfile/smokeProfile.service.ts` - Fixed `getCurrentSmokeProfile`, `saveCurrentSmokeProfile`
- `apps/backend/src/postSmoke/postSmoke.service.ts` - Fixed `getCurrentPostSmoke`, `saveCurrentPostSmoke`

### Changes include
- Early return with sensible defaults when state is null/undefined
- Early return when `smokeId` is empty or undefined
- Null checks for smoke objects before accessing their properties
- Auto-creation of state document in `update` method if none exists
- Return type updates to include `null` where appropriate

## Production Hotfix Applied
A temporary hotfix was applied to production by:
1. Inserting a default state document into MongoDB
2. Reconfiguring Tailscale Funnel to proxy port 8443 to the new backend port 3001

This PR provides the permanent code fix to prevent future occurrences.