### PR TITLE
fix: make cleanup steps best-effort to avoid additional failures

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -33,7 +33,7 @@ jobs:
           if [ "${DISK_USAGE}" -gt 80 ]; then
             echo "Disk usage exceeds 80%, running cleanup..."
             if [ -x /usr/local/bin/runner-cleanup.sh ]; then
-              sudo /usr/local/bin/runner-cleanup.sh
+              sudo /usr/local/bin/runner-cleanup.sh || echo "Cleanup script had issues, continuing..."
             else
               docker system prune -af --filter "until=24h" || true
               docker builder prune -af || true
@@ -325,10 +325,10 @@ jobs:
         run: |
           echo "Cleaning up runner disk space after deployment..."
           if [ -x /usr/local/bin/runner-cleanup.sh ]; then
-            sudo /usr/local/bin/runner-cleanup.sh
+            sudo /usr/local/bin/runner-cleanup.sh || echo "Cleanup script had issues, continuing..."
           else
             docker system prune -af --filter "until=24h" || true
             docker builder prune -af || true
           fi
           echo "Disk usage after cleanup:"
-          df -h /
+          df -h / || true


### PR DESCRIPTION
Follow-up fix to PR #156.

The cleanup steps were failing and causing additional job failures. This makes them best-effort by adding error handling so cleanup issues don't break the workflow.

**Changes:**
- Pre-deploy cleanup: Added `|| echo "..."` to handle script failures gracefully
- Post-deploy cleanup: Same error handling, plus `|| true` on final df command