### PR TITLE
feat(ci): Add Ansible provisioning workflow

### DIFF
--- a/.github/workflows/ansible-provision.yml
+++ b/.github/workflows/ansible-provision.yml
@@ -84,6 +84,7 @@ jobs:
     if: needs.prepare.outputs.is_prod == 'false'
     runs-on: [self-hosted, linux, proxmox]
     environment: development
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -97,7 +98,7 @@ jobs:
 
       - name: Install Ansible dependencies
         run: |
-          pip install --user ansible ansible-lint 2>/dev/null || pip install ansible ansible-lint
+          pip install --user ansible
           ansible-galaxy collection install community.general ansible.posix --force
 
       - name: Run Ansible playbook
@@ -105,7 +106,7 @@ jobs:
         run: |
           PLAYBOOK="${{ needs.prepare.outputs.playbook }}"
           DRY_RUN="${{ needs.prepare.outputs.dry_run }}"
-          
+
           echo "=========================================="
           echo "Ansible Provisioning"
           echo "=========================================="
@@ -113,13 +114,13 @@ jobs:
           echo "Environment: dev"
           echo "Dry Run: ${DRY_RUN}"
           echo "=========================================="
-          
+
           EXTRA_ARGS=""
           if [ "${DRY_RUN}" == "true" ]; then
             EXTRA_ARGS="--check --diff"
             echo "Running in CHECK MODE - no changes will be made"
           fi
-          
+
           # Limit to dev hosts only
           ansible-playbook playbooks/${PLAYBOOK} \
             --limit 'dev_cloud:devices:runners' \
@@ -135,12 +136,17 @@ jobs:
             --limit 'dev_cloud:devices:runners' \
             -v || echo "Verification completed with warnings"
 
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/id_ed25519
+
   # Provision prod environment (requires approval)
   provision-prod:
     needs: prepare
     if: needs.prepare.outputs.is_prod == 'true'
     runs-on: [self-hosted, linux, proxmox]
-    environment: production  # Requires approval if configured
+    environment: production # Requires approval if configured
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -154,7 +160,7 @@ jobs:
 
       - name: Install Ansible dependencies
         run: |
-          pip install --user ansible ansible-lint 2>/dev/null || pip install ansible ansible-lint
+          pip install --user ansible
           ansible-galaxy collection install community.general ansible.posix --force
 
       - name: Run Ansible playbook
@@ -162,7 +168,7 @@ jobs:
         run: |
           PLAYBOOK="${{ needs.prepare.outputs.playbook }}"
           DRY_RUN="${{ needs.prepare.outputs.dry_run }}"
-          
+
           echo "=========================================="
           echo "Ansible Provisioning - PRODUCTION"
           echo "=========================================="
@@ -170,13 +176,13 @@ jobs:
           echo "Environment: prod"
           echo "Dry Run: ${DRY_RUN}"
           echo "=========================================="
-          
+
           EXTRA_ARGS=""
           if [ "${DRY_RUN}" == "true" ]; then
             EXTRA_ARGS="--check --diff"
             echo "Running in CHECK MODE - no changes will be made"
           fi
-          
+
           # Limit to prod hosts only
           ansible-playbook playbooks/${PLAYBOOK} \
             --limit 'prod_cloud' \
@@ -192,6 +198,10 @@ jobs:
             --limit 'prod_cloud' \
             -v || echo "Verification completed with warnings"
 
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/id_ed25519
+
   # Summary notification
   notify:
     needs: [prepare, provision-dev, provision-prod]
@@ -204,7 +214,7 @@ jobs:
           PLAYBOOK="${{ needs.prepare.outputs.playbook }}"
           ENVIRONMENT="${{ needs.prepare.outputs.environment }}"
           DRY_RUN="${{ needs.prepare.outputs.dry_run }}"
-          
+
           if [ "${{ needs.provision-dev.result }}" == "success" ] || [ "${{ needs.provision-prod.result }}" == "success" ]; then
             STATUS="SUCCESS"
           elif [ "${{ needs.provision-dev.result }}" == "failure" ] || [ "${{ needs.provision-prod.result }}" == "failure" ]; then
@@ -212,7 +222,7 @@ jobs:
           else
             STATUS="UNKNOWN"
           fi
-          
+
           echo "=========================================="
           echo "Ansible Provisioning Complete"
           echo "=========================================="


### PR DESCRIPTION
## Summary

Add a new GitHub Actions workflow for running Ansible playbooks to provision infrastructure through CI/CD.

## Features

- **Automatic trigger**: Runs on push to master when Ansible files change (dev environment only for safety)
- **Manual trigger**: Select specific playbook, target environment (dev/prod), and optional dry-run mode
- **Production protection**: Uses GitHub `production` environment for approval workflow
- **Verification**: Runs `verify-all.yml` playbook after provisioning to confirm success
- **Self-hosted runner**: Runs on proxmox runner with Tailscale network access

## Workflow Inputs (Manual Trigger)

| Input | Options | Default |
|-------|---------|---------|
| `playbook` | setup-virtual-smoker.yml, setup-dev-cloud.yml, setup-prod-cloud.yml, setup-github-runner.yml, site.yml, verify-all.yml, verify-tailscale.yml | setup-virtual-smoker.yml |
| `environment` | dev, prod | dev |
| `dry_run` | true, false | false |

## Safety Measures

1. Automatic triggers only provision **dev** environment
2. Production requires manual trigger + environment approval (if configured)
3. Dry-run option previews changes without applying them
4. Concurrency limits prevent parallel provisioning runs

## Required Setup After Merge

To enable production protection:
1. Go to **Settings > Environments** in the repository
2. Create or edit the `production` environment
3. Add required reviewers for approval workflow

## Test Plan

- [ ] Merge PR and verify workflow appears in Actions tab
- [ ] Manually trigger with `dry_run: true` to verify it runs correctly
- [ ] Run actual provisioning for virtual-smoker device
- [ ] Verify SSH fix from PR #161 is applied by re-running dev-deploy workflow