### PR TITLE
fix(infra): Fix runner directory permissions (_diag owned by root)

### DIFF
--- a/infra/proxmox/ansible/roles/github-runner/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/github-runner/tasks/main.yml
@@ -19,6 +19,13 @@
     group: "{{ github_runner_user }}"
     mode: '0755'
 
+- name: Fix runner directory ownership
+  ansible.builtin.command:
+    cmd: "chown -R {{ github_runner_user }}:{{ github_runner_user }} {{ github_runner_install_dir }}"
+  changed_when: true
+  tags:
+    - permissions
+
 - name: Check if runner is already installed
   ansible.builtin.stat:
     path: "{{ github_runner_install_dir }}/config.sh"
@@ -218,6 +225,16 @@
         - (not runner_configured.stat.exists) or (runner_removed is defined and runner_removed.changed)
         - github_runner_token != ""
       changed_when: true
+
+    - name: Fix runner directory ownership after configuration
+      ansible.builtin.command:
+        cmd: "chown -R {{ github_runner_user }}:{{ github_runner_user }} {{ github_runner_install_dir }}"
+      when:
+        - (not runner_configured.stat.exists) or (runner_removed is defined and runner_removed.changed)
+        - github_runner_token != ""
+      changed_when: true
+      tags:
+        - permissions
 
     - name: Start and enable runner service
       ansible.builtin.command:

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-health-check.sh.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-health-check.sh.j2
@@ -140,6 +140,9 @@ sudo -u "$RUNNER_USER" ./config.sh \
     --replace \
     --unattended
 
+log "Fixing directory ownership..."
+chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR"
+
 log "Installing and starting service..."
 ./svc.sh install "$RUNNER_USER"
 ./svc.sh start


### PR DESCRIPTION
## Summary

Fixes all three self-hosted runner workflow failures after merging #164:
- Ansible Provision
- Self-Hosted Runner Test
- Dev Deploy

**Root cause:** The manual re-registration that was done earlier ran `config.sh` and `svc.sh` as root, leaving `/opt/actions-runner/_diag/` (and potentially other subdirectories) owned by `root`. The runner service runs as the `runner` user and gets `Access to the path '/opt/actions-runner/_diag/pages/...' is denied.`, causing every job to fail instantly after "Set up job".

**Fix:**
- Add `chown -R runner:runner /opt/actions-runner` at role startup to fix existing permissions
- Add the same ownership fix after re-registration in Ansible tasks (between install and start)
- Add `chown -R` to the self-healing script after re-registration to prevent future recurrence

## Test plan

- [ ] Ansible lint passes
- [ ] After merge, Ansible Provision workflow runs and fixes permissions on the runner
- [ ] Re-run Self-Hosted Runner Test -- should pass
- [ ] Re-run Dev Deploy -- should pass


Made with [Cursor](https://cursor.com)