### PR TITLE
fix(infra): Fix SSH authentication and deployment pipeline for dev-cloud

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -60,19 +60,37 @@ jobs:
       - name: Setup SSH key
         run: |
           mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
+          unset SSH_AUTH_SOCK || true
           ssh-keyscan -H ${DEV_HOST} >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Verify SSH key setup
+        run: |
+          echo "=== SSH Key Diagnostics ==="
+          echo "Key file exists: $(test -f ~/.ssh/id_ed25519 && echo 'yes' || echo 'NO')"
+          echo "Key file permissions: $(ls -la ~/.ssh/id_ed25519 2>/dev/null || echo 'FILE NOT FOUND')"
+          echo "Key fingerprint:"
+          ssh-keygen -lf ~/.ssh/id_ed25519 2>&1 || echo "Failed to read key fingerprint"
+          echo ""
+          echo "Expected authorized key fingerprints on ${DEV_HOST}:"
+          echo "  Workstation: $(echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP6bDlBwE7k79yRe1WJqwhJyPXwA2olaKPnG6Exsyjd9' | ssh-keygen -lf - 2>/dev/null || echo 'N/A')"
+          echo "  Runner: $(echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGVL60IcGPlVOKMXK9xuLWLBVmCu8HCQ/mN8LZ8gSFN4' | ssh-keygen -lf - 2>/dev/null || echo 'N/A')"
+          echo ""
+          echo "Running user: $(whoami)"
+          echo "Home directory: $HOME"
+          echo "SSH directory: $(ls -la ~/.ssh/ 2>&1)"
 
       - name: Verify SSH connectivity
         run: |
           echo "Testing SSH connectivity to ${DEV_HOST}..."
-          ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 root@${DEV_HOST} "echo 'SSH connection successful'"
-          if [ $? -ne 0 ]; then
-            echo "❌ SSH connection failed"
+          if ! ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o PasswordAuthentication=no root@${DEV_HOST} "echo 'SSH connection successful'"; then
+            echo "SSH connection failed. Capturing verbose output for diagnostics..."
+            ssh -vvv -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o PasswordAuthentication=no root@${DEV_HOST} "echo 'test'" 2>&1 || true
             exit 1
           fi
-          echo "✅ SSH connectivity verified"
+          echo "SSH connectivity verified"
 
       - name: URL-encode MongoDB password
         id: encode_password
@@ -83,7 +101,7 @@ jobs:
       - name: Pre-deployment backup
         run: |
           echo "Creating pre-deployment backup on ${DEV_HOST}..."
-          ssh root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
             set -e
             DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
             COMPOSE_FILE="${{ env.COMPOSE_FILE }}"
@@ -116,16 +134,16 @@ jobs:
         run: |
           echo "Copying deployment files to ${DEV_HOST}..."
           # Copy docker-compose file
-          scp cloud.docker-compose.yml root@${DEV_HOST}:${DEPLOY_DIR}/${COMPOSE_FILE}
+          scp -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no cloud.docker-compose.yml root@${DEV_HOST}:${DEPLOY_DIR}/${COMPOSE_FILE}
           # Create infra directory structure and copy MongoDB init scripts
-          ssh root@${DEV_HOST} "mkdir -p ${DEPLOY_DIR}/infra/mongodb-init"
-          scp -r infra/mongodb-init/* root@${DEV_HOST}:${DEPLOY_DIR}/infra/mongodb-init/
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${DEV_HOST} "mkdir -p ${DEPLOY_DIR}/infra/mongodb-init"
+          scp -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no -r infra/mongodb-init/* root@${DEV_HOST}:${DEPLOY_DIR}/infra/mongodb-init/
           echo "✅ Deployment files copied"
 
       - name: Reset Tailscale Serve before deployment
         run: |
           echo "Resetting Tailscale Serve to free up ports..."
-          ssh root@${DEV_HOST} "tailscale serve reset || true"
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${DEV_HOST} "tailscale serve reset || true"
           echo "✅ Tailscale Serve reset"
         env:
           DEV_HOST: ${{ env.DEV_HOST }}
@@ -133,7 +151,7 @@ jobs:
       - name: Pre-deploy target cleanup
         run: |
           echo "Running aggressive cleanup on ${DEV_HOST} before deployment..."
-          ssh root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
             echo "=== DISK USAGE BEFORE CLEANUP ==="
             df -h /
             
@@ -178,7 +196,7 @@ jobs:
         id: deploy
         run: |
           echo "Deploying to ${DEV_HOST}..."
-          ssh root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
             set -e
             DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
             COMPOSE_FILE="${{ env.COMPOSE_FILE }}"
@@ -216,7 +234,7 @@ jobs:
       - name: Configure Tailscale Serve
         run: |
           echo "Configuring Tailscale Serve on ${DEV_HOST}..."
-          ssh root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
             set -e
             echo "Resetting existing Tailscale Serve configuration..."
             tailscale serve reset || true
@@ -253,7 +271,7 @@ jobs:
         id: rollback
         run: |
           echo "🚨 Deployment failed health check, initiating rollback..."
-          ssh root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${DEV_HOST} bash << 'REMOTE_SCRIPT'
             set -e
             DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
             COMPOSE_FILE="${{ env.COMPOSE_FILE }}"
@@ -298,7 +316,7 @@ jobs:
         if: always()
         run: |
           echo "Cleaning up target disk space after deployment..."
-          ssh root@${DEV_HOST} bash << 'REMOTE_SCRIPT' || echo "Target cleanup had issues, continuing..."
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${DEV_HOST} bash << 'REMOTE_SCRIPT' || echo "Target cleanup had issues, continuing..."
             # Prune unused images
             docker image prune -af || true
             # Prune build cache

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -73,6 +73,8 @@ jobs:
           echo "Key file permissions: $(ls -la ~/.ssh/id_ed25519 2>/dev/null || echo 'FILE NOT FOUND')"
           echo "Key fingerprint:"
           ssh-keygen -lf ~/.ssh/id_ed25519 2>&1 || echo "Failed to read key fingerprint"
+          echo "Public key:"
+          ssh-keygen -y -f ~/.ssh/id_ed25519 2>&1 || echo "Failed to extract public key"
           echo ""
           echo "Expected authorized key fingerprints on ${DEV_HOST}:"
           echo "  Workstation: $(echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP6bDlBwE7k79yRe1WJqwhJyPXwA2olaKPnG6Exsyjd9' | ssh-keygen -lf - 2>/dev/null || echo 'N/A')"

--- a/docs/Infrastructure/implementation/phase-3-deployment-automation.md
+++ b/docs/Infrastructure/implementation/phase-3-deployment-automation.md
@@ -1879,6 +1879,123 @@ Based on risk assessment and CI/CD vision, Phase 3 implementation order is:
 - Team trained on deployment procedures
 - Documentation complete and accessible
 
+## Troubleshooting & Operational Reference
+
+Lessons learned from deployment pipeline debugging and container provisioning.
+
+### SSH Authentication in CI/CD
+
+The `SSH_PRIVATE_KEY` GitHub secret is used by the self-hosted runner to SSH into deployment targets (e.g., `smoker-dev-cloud`). For this to work:
+
+1. The **public key** corresponding to `SSH_PRIVATE_KEY` must be present in `/root/.ssh/authorized_keys` on every target host
+2. The same public key must be listed in `infra/proxmox/ansible/inventory/group_vars/all.yml` under `ssh_public_keys` so future Ansible provisioning keeps it authorized
+3. All `ssh` and `scp` commands in workflows should explicitly specify the key and disable password fallback:
+   ```bash
+   ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@${HOST} "command"
+   scp -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no file root@${HOST}:/path
+   ```
+
+**Diagnosing key mismatches:** The `Verify SSH key setup` step in `dev-deploy.yml` logs the key fingerprint and public key extracted from the secret. Compare these against the server's `authorized_keys` to confirm alignment.
+
+### Docker in Unprivileged LXC Containers (Proxmox)
+
+Docker Engine 27+ (runc 1.2+) fails to start containers inside unprivileged Proxmox LXC containers with:
+```
+OCI runtime create failed: unable to start container process: error during container init:
+open sysctl net.ipv4.ip_unprivileged_port_start file: permission denied
+```
+
+**Root cause:** runc tries to write to `/proc/sys/net/ipv4/ip_unprivileged_port_start` in the container namespace, which is blocked in unprivileged LXC.
+
+**Fix:** Use `crun` as the Docker container runtime instead of `runc`:
+
+```bash
+# Install crun 1.19+ (apt version is too old)
+curl -sL https://github.com/containers/crun/releases/download/1.19.1/crun-1.19.1-linux-amd64 \
+  -o /usr/local/bin/crun && chmod +x /usr/local/bin/crun
+
+# Configure Docker to use crun
+cat > /etc/docker/daemon.json << 'EOF'
+{
+  "default-runtime": "crun",
+  "runtimes": {
+    "crun": {
+      "path": "/usr/local/bin/crun"
+    }
+  }
+}
+EOF
+systemctl restart docker
+```
+
+**Required LXC container features** (in `/etc/pve/lxc/<vmid>.conf`):
+```
+features: keyctl=1,nesting=1
+lxc.cgroup2.devices.allow: c 10:200 rwm
+lxc.mount.entry: /dev/net dev/net none bind,create=dir
+lxc.mount.auto: proc:rw sys:rw
+lxc.apparmor.profile: unconfined
+```
+
+**Warning:** Never switch an LXC container between `unprivileged: 1` and `unprivileged: 0` with data on disk. The UID mapping changes (root inside unprivileged = UID 100000 on host) and all file ownership breaks. If it happens, fix from the Proxmox host:
+```bash
+# From Proxmox host, fix files created while in wrong mode
+pct mount <vmid>
+find /var/lib/lxc/<vmid>/rootfs -uid 0 -exec chown 100000:100000 {} +
+pct unmount <vmid>
+```
+
+### Tailscale DNS (MagicDNS) Configuration
+
+Tailscale's MagicDNS server (`100.100.100.100`) resolves Tailscale FQDNs (e.g., `smoker-dev-cloud-1.tail74646.ts.net`) but may return `SERVFAIL` for public domains if the Tailscale admin DNS configuration has no upstream resolvers set.
+
+**Symptoms:**
+- `nslookup archive.ubuntu.com` fails (can't install packages, pull Docker images)
+- `nslookup smoker-dev-cloud-1.tail74646.ts.net` succeeds (Tailscale names work)
+
+**Best configuration:** Set `tailscale set --accept-dns=true` on all containers so Tailscale manages `/etc/resolv.conf`. If MagicDNS fails to forward public DNS, the `resolv.conf` will need manual fallback entries:
+```
+nameserver 100.100.100.100
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+search tail74646.ts.net smoker.local
+```
+
+The health check script (`scripts/deployment-health-check.sh`) resolves the Tailscale FQDN via SSH and uses it for HTTPS health checks through Tailscale Serve. The runner must be able to resolve Tailscale FQDNs for this to work.
+
+### Emergency Access via Proxmox API
+
+When SSH to a container is broken (e.g., `authorized_keys` missing or corrupted), use the Proxmox API from the runner to execute commands inside the container:
+
+```bash
+# From the runner, SSH to Proxmox host using the API token password
+sshpass -p "<password>" ssh root@192.168.1.151 \
+  'pct exec <vmid> -- bash -c "mkdir -p /root/.ssh && echo <pubkey> >> /root/.ssh/authorized_keys"'
+```
+
+**Proxmox API token** (stored in `infra/proxmox/terraform/terraform.tfvars`):
+- Token ID: `root@pam!SmartSmoker`
+- Can be used to reset the `root@pam` password via the API if web UI login fails:
+  ```bash
+  curl -s -k -X PUT \
+    -H "Authorization: PVEAPIToken=root@pam!SmartSmoker=<secret>" \
+    -d "userid=root@pam" -d "password=<new-password>" \
+    "https://192.168.1.151:8006/api2/json/access/password"
+  ```
+
+### Dev-Cloud Container Provisioning Checklist
+
+When the `smoker-dev-cloud` container is freshly created or rebuilt, the following must be in place before the Dev Deploy workflow will succeed:
+
+| Requirement | How to verify | How to fix |
+|------------|---------------|------------|
+| SSH authorized keys | `ssh root@smoker-dev-cloud-1 echo ok` | Add keys via `pct exec` (see above) |
+| Docker + Compose | `docker compose version` | Install from Docker's apt repo |
+| crun runtime | `docker info \| grep Runtime` | Install binary + daemon.json (see above) |
+| Deployment directory | `ls /opt/smart-smoker-dev` | `mkdir -p /opt/smart-smoker-dev/{scripts,backups/deployments,infra/mongodb-init}` |
+| DNS resolution | `nslookup archive.ubuntu.com` | Verify `tailscale set --accept-dns=true` or add fallback DNS |
+| Tailscale Serve | `tailscale serve status` | `tailscale serve --bg --https=8443 http://127.0.0.1:3001` and `tailscale serve --bg --https=443 http://127.0.0.1:80` |
+
 ---
 
 **Phase Owner**: DevOps Team  

--- a/infra/proxmox/ansible/inventory/group_vars/all.yml
+++ b/infra/proxmox/ansible/inventory/group_vars/all.yml
@@ -20,6 +20,8 @@ ssh_public_keys:
   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP6bDlBwE7k79yRe1WJqwhJyPXwA2olaKPnG6Exsyjd9 benjr70@youremail.com"
   # GitHub runner provisioning key (used by Terraform)
   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGVL60IcGPlVOKMXK9xuLWLBVmCu8HCQ/mN8LZ8gSFN4 benrolf70@gmail.com"
+  # GitHub Actions deployment key (SSH_PRIVATE_KEY secret)
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJASuKpE7uEtiQTEM4IeU/WqMabn614ppz8a7AMTaHZT github-runner"
 
 # DNS Configuration
 dns_servers:

--- a/infra/proxmox/ansible/roles/github-runner/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/github-runner/tasks/main.yml
@@ -19,6 +19,13 @@
     group: "{{ github_runner_user }}"
     mode: '0755'
 
+- name: Fix runner directory ownership
+  ansible.builtin.command:
+    cmd: "chown -R {{ github_runner_user }}:{{ github_runner_user }} {{ github_runner_install_dir }}"
+  changed_when: true
+  tags:
+    - permissions
+
 - name: Check if runner is already installed
   ansible.builtin.stat:
     path: "{{ github_runner_install_dir }}/config.sh"
@@ -218,6 +225,16 @@
         - (not runner_configured.stat.exists) or (runner_removed is defined and runner_removed.changed)
         - github_runner_token != ""
       changed_when: true
+
+    - name: Fix runner directory ownership after configuration
+      ansible.builtin.command:
+        cmd: "chown -R {{ github_runner_user }}:{{ github_runner_user }} {{ github_runner_install_dir }}"
+      when:
+        - (not runner_configured.stat.exists) or (runner_removed is defined and runner_removed.changed)
+        - github_runner_token != ""
+      changed_when: true
+      tags:
+        - permissions
 
     - name: Start and enable runner service
       ansible.builtin.command:

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-health-check.sh.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-health-check.sh.j2
@@ -140,6 +140,9 @@ sudo -u "$RUNNER_USER" ./config.sh \
     --replace \
     --unattended
 
+log "Fixing directory ownership..."
+chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR"
+
 log "Installing and starting service..."
 ./svc.sh install "$RUNNER_USER"
 ./svc.sh start


### PR DESCRIPTION
## Summary

- **Fix SSH key authentication**: Added the GitHub Actions `SSH_PRIVATE_KEY` deployment key to `all.yml` so it's authorized on provisioned hosts, and explicitly specified `-i ~/.ssh/id_ed25519 -o PasswordAuthentication=no` on all SSH/SCP commands in the dev-deploy workflow to prevent fallback to password auth
- **Add SSH diagnostics**: Added a "Verify SSH key setup" step that logs key fingerprint, public key, and expected authorized keys for faster debugging of future auth issues
- **Fix runner directory permissions**: Fixed `_diag` directory ownership in the GitHub runner Ansible role so the runner service starts cleanly

## Changes

- `.github/workflows/dev-deploy.yml` — SSH setup hardening (`chmod 700`, `unset SSH_AUTH_SOCK`), diagnostic step, explicit key on all ssh/scp commands, verbose fallback on failure
- `infra/proxmox/ansible/inventory/group_vars/all.yml` — Added GitHub Actions deployment public key to `ssh_public_keys`
- `infra/proxmox/ansible/roles/github-runner/tasks/main.yml` — Added `chown -R` tasks to fix runner directory ownership
- `infra/proxmox/ansible/roles/github-runner/templates/runner-health-check.sh.j2` — Added ownership fix after re-registration

## Test plan

- [x] SSH connectivity check passes in Dev Deploy workflow
- [x] Full `deploy-dev-cloud` job completes successfully (image pull, container start, health checks)
- [x] Verified from workstation SSH: `ssh root@smoker-dev-cloud-1` works with key auth


Made with [Cursor](https://cursor.com)