### PR TITLE
fix(infra): self-heal qemu/binfmt on virtual-smoker + restore rollback compose pin

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -391,6 +391,7 @@ jobs:
       deploy_dir: '/opt/smoker-device'
       environment: 'dev'
       cloud_backend_url: 'https://smoker-dev-cloud.tail74646.ts.net:8443'
+      requires_arm_emulation: true
     secrets: inherit
 
   # Send combined notification for both deployments

--- a/.github/workflows/device-deploy.yml
+++ b/.github/workflows/device-deploy.yml
@@ -46,6 +46,10 @@ on:
         type: string
         default: 'https://smoker-dev-cloud.tail74646.ts.net:8443'
         description: 'Cloud backend URL for connectivity verification'
+      requires_arm_emulation:
+        type: boolean
+        default: false
+        description: 'Install qemu-user-static + binfmt registration on target before deploy (for amd64 hosts running arm/v7 images)'
   workflow_dispatch:
     inputs:
       device_host:
@@ -72,6 +76,10 @@ on:
       cloud_backend_url:
         type: string
         default: 'https://smoker-dev-cloud.tail74646.ts.net:8443'
+      requires_arm_emulation:
+        type: boolean
+        default: false
+        description: 'Install qemu-user-static + binfmt registration on target before deploy (for amd64 hosts running arm/v7 images)'
 
 permissions:
   contents: read
@@ -178,8 +186,37 @@ jobs:
             echo "✅ Sufficient disk space available"
           REMOTE_SCRIPT
 
+      - name: Ensure ARM emulation runtime
+        if: ${{ inputs.requires_arm_emulation }}
+        run: |
+          echo "Ensuring ARM emulation runtime on ${DEVICE_HOST}..."
+          if ssh ${SSH_USER}@${DEVICE_HOST} "update-binfmts --display qemu-arm 2>/dev/null | grep -q 'enabled = yes'"; then
+            echo "qemu-arm binfmt already registered"
+          else
+            echo "Installing qemu-user-static + binfmt-support and registering qemu-arm..."
+            ssh ${SSH_USER}@${DEVICE_HOST} "sudo DEBIAN_FRONTEND=noninteractive apt-get update && \
+              sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-user-static binfmt-support && \
+              sudo update-binfmts --enable qemu-arm"
+          fi
+
+          echo "Verifying arm/v7 emulation end-to-end..."
+          UNAME_OUT=$(ssh ${SSH_USER}@${DEVICE_HOST} "sudo docker run --rm --platform linux/arm/v7 alpine uname -m")
+          echo "uname -m under arm/v7 emulation: ${UNAME_OUT}"
+          if [ "${UNAME_OUT}" != "armv7l" ]; then
+            echo "❌ arm/v7 emulation verification failed: expected 'armv7l', got '${UNAME_OUT}'"
+            exit 1
+          fi
+          echo "✅ arm/v7 emulation runtime verified"
+
       - name: Create pre-deployment backup
         run: |
+          echo "Staging new compose on ${DEVICE_HOST} for backup overlay..."
+          # Push the new compose (about to be deployed) to a known temp path so the
+          # backup heredoc can overlay it onto the backup file. The rollback then
+          # restores a runnable compose (with current platform pin), not a stale
+          # pre-deploy compose that may pull a non-existent manifest.
+          scp ${COMPOSE_FILE} ${SSH_USER}@${DEVICE_HOST}:/tmp/${COMPOSE_FILE}.new
+
           echo "Creating pre-deployment backup on ${DEVICE_HOST}..."
           ssh ${SSH_USER}@${DEVICE_HOST} bash << REMOTE_SCRIPT
             set -e
@@ -187,21 +224,30 @@ jobs:
             COMPOSE_FILE="${COMPOSE_FILE}"
             TIMESTAMP=\$(date +%Y%m%d-%H%M%S)
             BACKUP_DIR="\${DEPLOY_DIR}/backups/backup-\${TIMESTAMP}"
-            
+
             # Create backup directory
             sudo mkdir -p "\${BACKUP_DIR}"
-            
+
             # Backup compose file if it exists
             if [ -f "\${DEPLOY_DIR}/\${COMPOSE_FILE}" ]; then
               sudo cp "\${DEPLOY_DIR}/\${COMPOSE_FILE}" "\${BACKUP_DIR}/\${COMPOSE_FILE}.backup"
             fi
-            
+
+            # Overlay backup with the NEW compose content (the one this deploy
+            # will install). Ensures rollback restores a compose with the current
+            # platform pin, not a stale pre-deploy compose pulling a missing
+            # manifest. See issue #193.
+            if [ -f "/tmp/\${COMPOSE_FILE}.new" ]; then
+              sudo cp "/tmp/\${COMPOSE_FILE}.new" "\${BACKUP_DIR}/\${COMPOSE_FILE}.backup"
+              rm -f "/tmp/\${COMPOSE_FILE}.new"
+            fi
+
             # Save current container state
             sudo docker compose -f "\${DEPLOY_DIR}/\${COMPOSE_FILE}" ps > "\${BACKUP_DIR}/compose-state.txt" 2>/dev/null || true
-            
+
             # Record this as the last backup
             echo "\${BACKUP_DIR}" | sudo tee "\${DEPLOY_DIR}/backups/last-deployment-backup.txt"
-            
+
             echo "✅ Backup created: \${BACKUP_DIR}"
           REMOTE_SCRIPT
 

--- a/infra/proxmox/ansible/README.md
+++ b/infra/proxmox/ansible/README.md
@@ -10,6 +10,14 @@ This Ansible configuration manages all server configuration for the Smart Smoker
 - **Production Cloud** - Production environment for cloud applications
 - **Virtual Smoker Device** - Virtual test device for development
 
+> **Note on virtual-smoker arm/v7 emulation**: `dev-deploy.yml` self-heals the
+> qemu/binfmt prereq when targeting `virtual-smoker` (via the
+> `requires_arm_emulation: true` input on the `device-deploy.yml` reusable
+> workflow), installing `qemu-user-static` + `binfmt-support` and registering
+> `qemu-arm` if missing. This is a deploy-time guard — a strict subset of the
+> Ansible `virtual-device` role, which remains canonical for fresh
+> provisioning and runbook procedures.
+
 ## Prerequisites
 
 ### Control Machine (Your Local Machine)


### PR DESCRIPTION
## Summary

Closes #193 — follow-up to closed issue #186 (PRD #184 slice 1).

PR #192 landed the static parts of arm/v7 emulation but virtual-smoker still failed to deploy because the Ansible role that registers `binfmt_misc` was never applied to the live host. Live evidence:

```
device_service   Restarting (255)
$ docker logs device_service
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```

A second, independent rollback hole was exposed by arm/v7-only publishing: `device-deploy.yml` restored an old compose backup (no `platform:` line) → docker pulled amd64 → no manifest → rollback always failed.

This PR fixes both inside `.github/workflows/`. No changes to Dockerfile, publish.yml, the Ansible role, or compose — those landed correctly in PR #192.

## What changed

- **`.github/workflows/device-deploy.yml`**
  - New input `requires_arm_emulation: bool` (default `false`) on both `workflow_call` and `workflow_dispatch`.
  - New step **"Ensure ARM emulation runtime"** gated by that input. Probes `update-binfmts --display qemu-arm` for `enabled = yes`; installs `qemu-user-static` + `binfmt-support` and runs `update-binfmts --enable qemu-arm` if missing. Verifies `docker run --platform linux/arm/v7 alpine uname -m` returns `armv7l` UNCONDITIONALLY (after the if/else closes), so the assertion catches half-applied state regardless of starting point.
  - Pre-deployment backup step now overlays the *new* compose into `${BACKUP_DIR}/${COMPOSE_FILE}.backup` via an early `scp /tmp/${COMPOSE_FILE}.new` + heredoc copy. Rollback restores a runnable compose, not a stale pre-#192 amd64-pulling one.

- **`.github/workflows/dev-deploy.yml`** — passes `requires_arm_emulation: true` only at the virtual-smoker call site. Pi production deploy is unaffected.

- **`infra/proxmox/ansible/README.md`** — one paragraph documenting the deploy-time self-heal vs. the Ansible `virtual-device` role (which stays canonical for fresh provisioning).

## Acceptance criteria (from #193)

- [x] `requires_arm_emulation: bool` (default false) on both `workflow_call` and `workflow_dispatch` inputs of `device-deploy.yml`
- [x] New "Ensure ARM emulation runtime" step gated by that input, idempotent, verify `docker run --platform linux/arm/v7 alpine uname -m == armv7l` runs unconditionally
- [x] `dev-deploy.yml` passes `requires_arm_emulation: true` for the virtual-smoker target only
- [x] Pre-deployment backup step writes the *new* compose content into the backup file
- [x] `infra/proxmox/ansible/README.md` documents the deploy-time self-heal vs. role-applied provisioning
- [ ] Re-dispatched `dev-deploy.yml` reaches `success` for `deploy-virtual-smoker / deploy-device` — gated to post-merge live verification
- [ ] `ssh smoker@virtual-smoker-device "docker logs device_service"` shows NestJS bootstrap, not `exec format error` — gated to post-merge
- [ ] `docker exec device_service uname -m` returns `armv7l` — gated to post-merge
- [ ] Rollback verification: force a probe failure on a throwaway branch, confirm rollback restores a compose pinned to `linux/arm/v7` and pulls cleanly — gated to post-merge

## Test plan

- [x] CI — workflow lint + repo's existing yamllint
- [ ] After merge, dispatch `dev-deploy.yml` against master:
  - First run: "Ensure ARM emulation runtime" installs qemu + registers handler, verify line returns `armv7l`
  - Second run: step short-circuits with "binfmt already registered", verify still passes
  - `deploy-virtual-smoker / deploy-device` reaches `success`
- [ ] On virtual-smoker after deploy:
  - `docker ps` shows `device_service` `Up (healthy)`, no restart loop
  - `docker logs device_service | head -20` shows NestJS bootstrap output
  - `docker exec device_service uname -m` returns `armv7l`
- [ ] Rollback drill: temporarily break a probe in `device-health-check.sh` on a throwaway branch, dispatch the deploy, observe rollback `docker compose pull` succeed (not "no matching manifest")

## Notes

- Issue #186 stays closed; this PR does not amend it. The Ansible task block in `infra/proxmox/ansible/roles/virtual-device/tasks/main.yml` remains the source of truth for fresh provisioning. The deploy-time guard is a strict subset.
- The watchtower restart loop visible in the live `docker ps` snapshot is unrelated and not addressed here.
- Hostname source-of-truth (#189), DNS persistence (#188), runner self-heal (#190), end-to-end verify (#191) — separate slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)