### PR TITLE
fix(scripts): probe /api/health for device service health check

### DIFF
--- a/scripts/device-health-check.sh
+++ b/scripts/device-health-check.sh
@@ -215,8 +215,10 @@ main() {
         URL_BASE="http://${TARGET_HOST}"
     fi
 
-    # Check Device Service
-    if ! check_service "Device Service" "${URL_BASE}:${DEVICE_SERVICE_PORT}/health"; then
+    # Check Device Service. NestJS app uses globalPrefix 'api', so the
+    # health controller is mounted under /api/health (matches the cloud
+    # backend probe path below).
+    if ! check_service "Device Service" "${URL_BASE}:${DEVICE_SERVICE_PORT}/api/health"; then
         ((failed++)) || true
     fi
     echo ""


### PR DESCRIPTION
## Summary

Follow-up to merged PR #195. After PR #195 landed, dev-deploy run [25286296144](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/25286296144) showed `device_service` container `running` cleanly under qemu emulation but health check still failed. Live root cause:

```
device_service log:
  GET /health      -> 404
device_service log + curl localhost:3003/api/health:
  {"status":"ok","timestamp":"2026-05-03T17:54:41.181Z","uptime":203.017056206,"environment":"local"}
```

`apps/device-service/src/main.ts` calls `app.setGlobalPrefix('api')`, so the health controller is mounted at `/api/health`. The probe in `scripts/device-health-check.sh:219` was hitting plain `/health` → 404. Internal inconsistency: the cloud backend probe in the same script (line 172) already used `/api/health` correctly.

This was masked by all prior failure modes (exec format error → pino-pretty crash) — the path bug never got exercised because the app never reached the listening state. Now that #186/#193/#195 cleared the runtime, the path mismatch surfaces.

## What changed

- **`scripts/device-health-check.sh:219`** — probe path changed from `${URL_BASE}:${DEVICE_SERVICE_PORT}/health` to `${URL_BASE}:${DEVICE_SERVICE_PORT}/api/health`. Inline comment explains the global-prefix reasoning.

## Test plan

- [x] Live verification on virtual-smoker post-#195: `curl http://localhost:3003/api/health` returns 200 with `status:ok`
- [ ] After merge, dispatch `dev-deploy.yml`. Expect `Device Service` health probe `✅ healthy` first attempt
- [ ] `deploy-virtual-smoker / deploy-device` reaches `success` (modulo cloud backend probe still hitting hardcoded `smoker-dev-cloud` without `-1` — that's PRD #184 issue #189 scope, separate)

## Notes

- Watchtower restart loop (`Docker API version 1.25 too old`) shows in same `docker ps` snapshot; pre-existing, unrelated to PRD #184.
- This continues the closed-issue trail: #186 → #193 → followed up via PR #195 + this PR. Comment will be added to #193 with the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)