### PR TITLE
fix(infra): pin watchtower to 1.5.3 for older Docker daemon on virtual-smoker

### DIFF
--- a/virtual-smoker.docker-compose.yml
+++ b/virtual-smoker.docker-compose.yml
@@ -71,7 +71,12 @@ services:
 
   watchtower:
     container_name: watchtower
-    image: containrrr/watchtower:latest # Use amd64 image, not armhf
+    # Pinned: watchtower 1.6.0+ bundles a Docker SDK that requires daemon
+    # API >= 1.44 (Docker Engine 25+). virtual-smoker runs an older
+    # daemon, so :latest crashloops with "client version 1.25 too old".
+    # 1.5.3 (Jan 2023) is the last release whose SDK negotiates against
+    # the host's daemon API. Bump only when the daemon is upgraded.
+    image: containrrr/watchtower:1.5.3 # amd64; do not use armhf
     restart: always
     environment:
       - REPO_USER=${REPO_USER:-}


### PR DESCRIPTION
## Summary

Watchtower 1.6.0+ bundles a Docker SDK that requires daemon API >= 1.44 (Docker Engine 25+). virtual-smoker runs an older daemon, so `containrrr/watchtower:latest` crashlooped with:

```
Error response from daemon: client version 1.25 is too old.
Minimum supported API version is 1.44, please upgrade your client to a newer version
```

The container-count probe in `device-health-check.sh` then reported `2/3` (watchtower restarting) and failed dev-deploy. After PRs #186 / #194 / #195 / #196 cleared every other failure mode, this is the last gating issue on virtual-smoker (excluding the cloud-backend hostname drift, which is PRD #184 issue #189).

Live evidence — run [25286707443](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/25286707443):

```
✅ Device Service is healthy   (after #196 path fix)
✅ Smoker Frontend is healthy
✅ device_service: running
✅ frontend_smoker: running
❌ watchtower: restarting       ← this PR's target
❌ Some containers not running (2/3)
```

## What changed

- **`virtual-smoker.docker-compose.yml`** — pin `containrrr/watchtower:latest` → `containrrr/watchtower:1.5.3` (Jan 2023, last release with an SDK that negotiates against the host daemon's API). Inline comment explains the constraint and when to bump (i.e. only after upgrading the virtual-smoker Docker daemon).

## Test plan

- [x] Image confirmed available on Docker Hub (`containrrr/watchtower:1.5.3` published 2023-01-30)
- [ ] After merge → next nightly republishes the same `:nightly` images → dev-deploy chains
- [ ] Expected: `watchtower` container reaches steady state (no restart loop), container-count probe reports `3/3`, deploy reaches `success`
- [ ] Cloud backend probe will still fail on hardcoded `smoker-dev-cloud` URL — that's PRD #184 issue #189 scope, out of scope for this PR

## Notes

- Watchtower's purpose on virtual-smoker is auto-updating containers on the device. Alternative was to remove watchtower entirely (dev-deploy already pushes new images per nightly), but pinning preserves parity with the production Pi deploy semantics.
- The Docker daemon upgrade path is a separate operator task; pin documents the constraint in-tree so it doesn't get re-broken by automated `:latest` upgrades.
- This continues the closed-issue trail: #186 → #193 → followed up by PRs #195, #196, and now this. Comment will be added to #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)