### PR TITLE
fix(infra): switch watchtower to latest-dev + pin DOCKER_API_VERSION

### DIFF
--- a/virtual-smoker.docker-compose.yml
+++ b/virtual-smoker.docker-compose.yml
@@ -71,12 +71,16 @@ services:
 
   watchtower:
     container_name: watchtower
-    # Pinned: watchtower 1.6.0+ bundles a Docker SDK that requires daemon
-    # API >= 1.44 (Docker Engine 25+). virtual-smoker runs an older
-    # daemon, so :latest crashloops with "client version 1.25 too old".
-    # 1.5.3 (Jan 2023) is the last release whose SDK negotiates against
-    # the host's daemon API. Bump only when the daemon is upgraded.
-    image: containrrr/watchtower:1.5.3 # amd64; do not use armhf
+    # Released `containrrr/watchtower` builds (incl. 1.5.3 and 1.7.1) ship
+    # a Docker SDK whose default negotiated API is ~1.25. virtual-smoker's
+    # daemon (Docker 26+) refuses to speak older than 1.44 and the
+    # container crashloops with "client version 1.25 too old". The
+    # `latest-dev` build (Jan 2024) carries the upstream API-negotiation
+    # patch. Belt + suspenders: also pin DOCKER_API_VERSION in env so the
+    # SDK is forced onto a daemon-compatible version even if the patch
+    # regresses. Move back to a stable tag once a published release with
+    # API negotiation lands.
+    image: containrrr/watchtower:latest-dev # amd64; do not use armhf
     restart: always
     environment:
       - REPO_USER=${REPO_USER:-}
@@ -84,6 +88,7 @@ services:
       - WATCHTOWER_CLEANUP=true
       - WATCHTOWER_POLL_INTERVAL=300
       - WATCHTOWER_LABEL_ENABLE=false
+      - DOCKER_API_VERSION=1.44
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: --interval 300 --cleanup device_service frontend_smoker


### PR DESCRIPTION
## Summary

Pinning watchtower to `1.5.3` in PR #197 didn't help: dev-deploy run [25287210026](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/25287210026) shows the same error against the new image:

```
client version 1.25 is too old. Minimum supported API version is 1.44
```

Released `containrrr/watchtower` builds (1.5.3 and 1.7.1 both confirmed) bundle a Docker SDK whose negotiated default API is ~1.25. virtual-smoker's daemon is Docker 26+ which refuses to speak older than API 1.44, so every released tag crashloops the same way.

The `latest-dev` build (Jan 2024) carries the upstream API-negotiation patch. Adding `DOCKER_API_VERSION=1.44` as a fallback forces the SDK onto a daemon-compatible API even if the negotiation regresses on a future `latest-dev` build.

## What changed

- **`virtual-smoker.docker-compose.yml`**
  - `containrrr/watchtower:1.5.3` → `containrrr/watchtower:latest-dev`
  - Added `DOCKER_API_VERSION=1.44` to the watchtower env block
  - Updated inline comment with the rationale

Container parity with the production Pi (older daemon, `:latest` fine) preserved — watchtower stays in the compose file per the user's preference for matching prod deploy semantics.

## Test plan

- [ ] After merge → next nightly republishes images → dev-deploy chains
- [ ] Expected: `watchtower` container reaches steady state (no restart loop), container-count probe `3/3`, deploy `success`
- [ ] Cloud backend probe will still fail on hardcoded `smoker-dev-cloud` URL — that's PRD #184 issue #189 scope, separate

## Notes

- If `latest-dev` is unstable (it's a rolling tag), can pin to a digest later. For now the floating tag is acceptable to get unblocked.
- Move back to a pinned stable release once upstream publishes a 1.x or 2.x with `WithAPIVersionNegotiation`.
- This continues the trail: #186 → #193 → PRs #195, #196, #197, and now this. Comment will be added to #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)