### PR TITLE
Closes #187: Hostname resolver helper + deployment-health-check + verify-deploy consumers

### DIFF
--- a/.claude/skills/verify-deploy/SKILL.md
+++ b/.claude/skills/verify-deploy/SKILL.md
@@ -32,13 +32,34 @@ Optional positional arg:
 
 ## Targets
 
-- **dev-cloud**: host `smoker-dev-cloud-1`, FQDN
-  `smoker-dev-cloud-1.tail74646.ts.net`, Tailscale Serve on 443 (frontend) +
-  8443 (backend). Containers: `backend_cloud`, `frontend_cloud`, `mongo`. (Peer
-  renamed from `smoker-dev-cloud` after re-provisioning; confirm with
-  `tailscale status | grep smoker-dev-cloud` if probes 404 unexpectedly.)
+- **dev-cloud**: host `smoker-dev-cloud-1`, FQDN resolved via
+  `scripts/smoke/resolve-host-cli.ts` (see **FQDN Resolution** below).
+  Tailscale Serve on 443 (frontend) + 8443 (backend). Containers:
+  `backend_cloud`, `frontend_cloud`, `mongo`.
 - **virtual-smoker**: host `virtual-smoker`, SSH user `smoker`. Containers:
   `device_service`, `frontend_smoker`, `watchtower`.
+
+## FQDN Resolution
+
+All Tailscale peer FQDNs **must** be computed via the resolver — never hardcode
+FQDNs or inline `tailscale status --self --json | jq` pipes.
+
+```bash
+# Resolve any short name or FQDN → canonical ts.net FQDN
+node --import tsx/esm scripts/smoke/resolve-host-cli.ts smoker-dev-cloud-1
+# → smoker-dev-cloud-1.tail74646.ts.net
+```
+
+The resolver (`scripts/smoke/resolve-host.ts`) handles:
+- Short hostname → peer lookup via `tailscale status --json`
+- Exact FQDN passthrough (strips trailing `.`)
+- Suffix drift (`smoker-dev-cloud` → `smoker-dev-cloud-1`)
+- Multi-suffix ambiguity: picks highest numeric suffix, emits a warning
+- No-match: throws with actionable message (exits non-zero)
+
+`scripts/deployment-health-check.sh` already calls the resolver for all
+non-localhost targets. When referencing the dev-cloud FQDN in step 3 below,
+obtain it from the resolver rather than hardcoding it.
 
 ## Steps (run sequentially, fail-fast)
 

--- a/scripts/deployment-health-check.sh
+++ b/scripts/deployment-health-check.sh
@@ -52,12 +52,18 @@ main() {
     echo ""
 
     # For remote hosts, get the full Tailscale FQDN for HTTPS requests
-    # Tailscale Serve requires the full FQDN for TLS SNI matching
+    # Tailscale Serve requires the full FQDN for TLS SNI matching.
+    # Resolution is delegated to scripts/smoke/resolve-host-cli.ts which
+    # handles short names, FQDNs, suffix drift, and multi-peer disambiguation.
     if [ "${TARGET_HOST}" != "localhost" ] && [ "${TARGET_HOST}" != "127.0.0.1" ]; then
         echo -e "${YELLOW}Resolving Tailscale FQDN for ${TARGET_HOST}...${NC}"
-        TAILSCALE_FQDN=$(ssh "root@${TARGET_HOST}" "tailscale status --self --json | jq -r '.Self.DNSName' | sed 's/\.$//'")
-        if [ -z "${TAILSCALE_FQDN}" ] || [ "${TAILSCALE_FQDN}" = "null" ]; then
-            echo -e "${RED}❌ Failed to resolve Tailscale FQDN${NC}"
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        if ! TAILSCALE_FQDN=$(node --import tsx/esm "${SCRIPT_DIR}/smoke/resolve-host-cli.ts" "${TARGET_HOST}" 2>&1); then
+            echo -e "${RED}❌ Failed to resolve Tailscale FQDN: ${TAILSCALE_FQDN}${NC}"
+            exit 1
+        fi
+        if [ -z "${TAILSCALE_FQDN}" ]; then
+            echo -e "${RED}❌ Tailscale FQDN resolved to empty string${NC}"
             exit 1
         fi
         echo -e "${GREEN}✅ Resolved to: ${TAILSCALE_FQDN}${NC}"

--- a/scripts/smoke/fixtures/tailscale-status.json
+++ b/scripts/smoke/fixtures/tailscale-status.json
@@ -1,0 +1,20 @@
+{
+  "Self": {
+    "HostName": "my-local-machine",
+    "DNSName": "my-local-machine.tail74646.ts.net."
+  },
+  "Peer": {
+    "abc123": {
+      "HostName": "smoker-dev-cloud-1",
+      "DNSName": "smoker-dev-cloud-1.tail74646.ts.net."
+    },
+    "def456": {
+      "HostName": "smoker-dev-cloud-2",
+      "DNSName": "smoker-dev-cloud-2.tail74646.ts.net."
+    },
+    "ghi789": {
+      "HostName": "virtual-smoker",
+      "DNSName": "virtual-smoker.tail74646.ts.net."
+    }
+  }
+}

--- a/scripts/smoke/package.json
+++ b/scripts/smoke/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "smoke": "tsx run.ts",
-    "smoke:install": "playwright install --with-deps chromium"
+    "smoke:install": "playwright install --with-deps chromium",
+    "test": "tsx --test *.test.ts"
   },
   "dependencies": {
     "playwright": "^1.49.0"

--- a/scripts/smoke/resolve-host-cli.ts
+++ b/scripts/smoke/resolve-host-cli.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * Thin CLI wrapper around resolvePeerHostname.
+ * Usage: node --import tsx/esm scripts/smoke/resolve-host-cli.ts <host>
+ * Prints the resolved FQDN to stdout and exits 0, or prints an error to stderr and exits 1.
+ */
+import { resolvePeerHostname, defaultSshRunner } from './resolve-host.js';
+
+const input = process.argv[2];
+
+if (!input) {
+  process.stderr.write('Usage: resolve-host-cli.ts <hostname-or-fqdn>\n');
+  process.exit(1);
+}
+
+resolvePeerHostname(input, defaultSshRunner)
+  .then(fqdn => {
+    process.stdout.write(fqdn + '\n');
+    process.exit(0);
+  })
+  .catch((err: unknown) => {
+    process.stderr.write(`resolve-host: ${(err as Error).message}\n`);
+    process.exit(1);
+  });

--- a/scripts/smoke/resolve-host.test.ts
+++ b/scripts/smoke/resolve-host.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for resolvePeerHostname
+ * Uses node:test (zero-dep) + assert/strict
+ * Fixture: fixtures/tailscale-status.json
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+import { resolvePeerHostname, type SshRunner } from './resolve-host.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Load fixture once
+const fixtureJson = readFileSync(
+  join(__dirname, 'fixtures', 'tailscale-status.json'),
+  'utf-8',
+);
+
+/** Stub SshRunner that always returns the fixture JSON */
+const stubSshRunner: SshRunner = async (_host: string, _cmd: string) =>
+  fixtureJson;
+
+/** Stub that returns fixture JSON containing only one peer with "smoker-dev-cloud-1" */
+const singlePeerFixture = JSON.stringify({
+  Self: {
+    HostName: 'my-local-machine',
+    DNSName: 'my-local-machine.tail74646.ts.net.',
+  },
+  Peer: {
+    abc123: {
+      HostName: 'smoker-dev-cloud-1',
+      DNSName: 'smoker-dev-cloud-1.tail74646.ts.net.',
+    },
+  },
+});
+
+const singlePeerRunner: SshRunner = async () => singlePeerFixture;
+
+describe('resolvePeerHostname', () => {
+  describe('case (a): exact FQDN passthrough', () => {
+    it('returns the FQDN as-is when input ends with .ts.net', async () => {
+      const result = await resolvePeerHostname(
+        'smoker-dev-cloud-1.tail74646.ts.net',
+        stubSshRunner,
+      );
+      assert.equal(result, 'smoker-dev-cloud-1.tail74646.ts.net');
+    });
+
+    it('strips trailing dot when input is a raw DNS FQDN with trailing dot', async () => {
+      const result = await resolvePeerHostname(
+        'smoker-dev-cloud-1.tail74646.ts.net.',
+        stubSshRunner,
+      );
+      assert.equal(result, 'smoker-dev-cloud-1.tail74646.ts.net');
+    });
+  });
+
+  describe('case (b): short name to FQDN expansion', () => {
+    it('resolves a short hostname to its full FQDN via peer lookup', async () => {
+      const result = await resolvePeerHostname(
+        'smoker-dev-cloud-1',
+        singlePeerRunner,
+      );
+      assert.equal(result, 'smoker-dev-cloud-1.tail74646.ts.net');
+    });
+
+    it('resolves Self.HostName if it matches the input', async () => {
+      const selfFixture = JSON.stringify({
+        Self: {
+          HostName: 'smoker-dev-cloud-1',
+          DNSName: 'smoker-dev-cloud-1.tail74646.ts.net.',
+        },
+        Peer: {},
+      });
+      const runner: SshRunner = async () => selfFixture;
+      const result = await resolvePeerHostname('smoker-dev-cloud-1', runner);
+      assert.equal(result, 'smoker-dev-cloud-1.tail74646.ts.net');
+    });
+  });
+
+  describe('case (c): no-match throws', () => {
+    it('throws with an actionable message when no peer matches', async () => {
+      await assert.rejects(
+        () => resolvePeerHostname('nonexistent-host', stubSshRunner),
+        (err: unknown) => {
+          assert.ok(err instanceof Error);
+          assert.ok(
+            err.message.includes('nonexistent-host'),
+            `Expected error message to include hostname, got: ${err.message}`,
+          );
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('case (d): multi-suffix → highest with warning', () => {
+    it('returns the peer with the highest numeric suffix when multiple match', async () => {
+      // fixture has smoker-dev-cloud-1 and smoker-dev-cloud-2
+      // The base name "smoker-dev-cloud" matches both; should pick -2 (highest)
+      const multiFixture = JSON.stringify({
+        Self: {
+          HostName: 'my-local-machine',
+          DNSName: 'my-local-machine.tail74646.ts.net.',
+        },
+        Peer: {
+          abc123: {
+            HostName: 'smoker-dev-cloud-1',
+            DNSName: 'smoker-dev-cloud-1.tail74646.ts.net.',
+          },
+          def456: {
+            HostName: 'smoker-dev-cloud-2',
+            DNSName: 'smoker-dev-cloud-2.tail74646.ts.net.',
+          },
+        },
+      });
+      const runner: SshRunner = async () => multiFixture;
+
+      // Capture console.warn output
+      const warnMessages: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warnMessages.push(args.map(String).join(' '));
+      };
+
+      let result: string;
+      try {
+        result = await resolvePeerHostname('smoker-dev-cloud', runner);
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assert.equal(result!, 'smoker-dev-cloud-2.tail74646.ts.net');
+      assert.ok(
+        warnMessages.length > 0,
+        'Expected at least one console.warn to be emitted',
+      );
+    });
+  });
+});

--- a/scripts/smoke/resolve-host.ts
+++ b/scripts/smoke/resolve-host.ts
@@ -1,0 +1,131 @@
+/**
+ * Tailscale peer-name resolver.
+ *
+ * Resolves a short hostname or FQDN to a full Tailscale FQDN
+ * (e.g. `smoker-dev-cloud-1.tail74646.ts.net`).
+ *
+ * Injectable SshRunner for testability — production uses execFile('ssh', ...).
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/** Function that SSHes into `host` and returns stdout of `command`. */
+export type SshRunner = (host: string, command: string) => Promise<string>;
+
+/** Production SSH runner — connects as root@host. */
+export const defaultSshRunner: SshRunner = async (
+  host: string,
+  command: string,
+): Promise<string> => {
+  const { stdout } = await execFileAsync('ssh', [`root@${host}`, command]);
+  return stdout;
+};
+
+interface TailscaleNode {
+  HostName: string;
+  DNSName: string;
+}
+
+interface TailscaleStatus {
+  Self: TailscaleNode;
+  Peer: Record<string, TailscaleNode>;
+}
+
+/**
+ * Strip trailing dot from a DNS name.
+ * Tailscale always emits `hostname.tailnet.ts.net.` — strip the dot.
+ */
+function stripTrailingDot(name: string): string {
+  return name.endsWith('.') ? name.slice(0, -1) : name;
+}
+
+/**
+ * Resolve a short hostname or FQDN to its full Tailscale FQDN.
+ *
+ * Cases:
+ *  (a) `input` already ends in `.ts.net` (±trailing dot) → strip dot, return.
+ *  (b) `input` matches `Self.HostName` or a `Peer[*].HostName` → return their DNSName.
+ *  (c) No match → throw with actionable message.
+ *  (d) Multiple numbered peers share the same base → warn and return highest.
+ */
+export async function resolvePeerHostname(
+  input: string,
+  sshRunner: SshRunner,
+): Promise<string> {
+  // (a) Already a FQDN
+  const normalised = stripTrailingDot(input);
+  if (normalised.includes('.ts.net')) {
+    return normalised;
+  }
+
+  // Need to SSH in and ask Tailscale
+  const raw = await sshRunner(input, 'tailscale status --json');
+  let status: TailscaleStatus;
+  try {
+    status = JSON.parse(raw) as TailscaleStatus;
+  } catch {
+    throw new Error(
+      `resolve-host: failed to parse tailscale status JSON from ${input}: ${raw.slice(0, 200)}`,
+    );
+  }
+
+  if (!status.Self || !status.Self.HostName || !status.Self.DNSName) {
+    throw new Error(
+      `resolve-host: tailscale status response from ${input} is missing Self.HostName / Self.DNSName`,
+    );
+  }
+
+  // (b) Check Self first
+  if (status.Self.HostName === input) {
+    return stripTrailingDot(status.Self.DNSName);
+  }
+
+  // Gather all peers
+  const peers = Object.values(status.Peer ?? {});
+
+  // Exact match in peers
+  const exactMatch = peers.find(p => p.HostName === input);
+  if (exactMatch) {
+    return stripTrailingDot(exactMatch.DNSName);
+  }
+
+  // (d) Multi-suffix: find peers whose HostName matches `<input>-<number>`
+  const suffixRe = new RegExp(`^${escapeRegex(input)}-(\\d+)$`);
+  const numberedMatches = peers
+    .filter(p => suffixRe.test(p.HostName))
+    .map(p => {
+      const m = suffixRe.exec(p.HostName)!;
+      return { peer: p, suffix: parseInt(m[1], 10) };
+    });
+
+  if (numberedMatches.length > 1) {
+    numberedMatches.sort((a, b) => b.suffix - a.suffix);
+    const winner = numberedMatches[0];
+    const allNames = numberedMatches.map(m => m.peer.HostName).join(', ');
+    console.warn(
+      `resolve-host: WARNING — multiple peers match "${input}": [${allNames}]. ` +
+        `Using highest suffix: ${winner.peer.HostName}`,
+    );
+    return stripTrailingDot(winner.peer.DNSName);
+  }
+
+  if (numberedMatches.length === 1) {
+    return stripTrailingDot(numberedMatches[0].peer.DNSName);
+  }
+
+  // (c) No match
+  const knownHosts = [status.Self.HostName, ...peers.map(p => p.HostName)].join(
+    ', ',
+  );
+  throw new Error(
+    `resolve-host: no Tailscale peer found matching "${input}". ` +
+      `Known hosts: ${knownHosts}. ` +
+      `Run \`tailscale status\` on the machine to verify peer names.`,
+  );
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/smoke/tsconfig.json
+++ b/scripts/smoke/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["run.ts"]
+  "include": ["*.ts"]
 }


### PR DESCRIPTION
## Summary

Introduces `scripts/smoke/resolve-host.ts` as a single deep module owning Tailscale peer-name resolution. Replaces the ad-hoc inline `tailscale status --self --json | jq` call in `deployment-health-check.sh` and documents the resolver as the canonical source of FQDNs in the `verify-deploy` skill.

- New `resolve-host.ts` handles FQDN passthrough, short-name peer lookup, suffix-drift disambiguation, multi-suffix warning, and actionable no-match errors
- `resolve-host-cli.ts` provides a thin shell-callable wrapper
- 6 unit tests (node:test, zero-dep) via stub SshRunner — no live tailnet calls
- `deployment-health-check.sh` now delegates FQDN resolution instead of inlining SSH+jq
- `verify-deploy/SKILL.md` gains a FQDN Resolution section; hardcoded FQDNs removed

## Closes

Closes #187 — Hostname resolver helper + deployment-health-check + verify-deploy consumers

## Smoke

`smoke: SKIPPED — local services not available (backend/frontend not running, Playwright not installed in this environment)`

## Manual verification

- [ ] Resolver lives under `scripts/smoke/` as a TS module (matching existing `scripts/smoke/run.ts` prior art) and exposes a stable signature `(input: string, sshRunner) => Promise<string>`.
- [ ] Resolver behavior cases:
  - (a) input is exact FQDN that resolves → returned unchanged.
  - (b) input is short name with `-1` peer present → returns `-1.tail74646.ts.net`.
  - (c) input has no matching peer → exit non-zero / throw with a clear, actionable message naming the input.
  - (d) input matches multiple numbered peers (`-1`, `-2`, …) → returns highest numeric suffix and emits a warning.
- [ ] Unit tests under the existing tsx harness use a fixture `tailscale status --json` payload — no live tailnet calls.
- [ ] `scripts/deployment-health-check.sh` calls the resolver (directly or via a tiny shell wrapper) instead of inlining `tailscale status --self --json | jq`. Accepts either short name or full FQDN as `$1`.
- [ ] `.claude/skills/verify-deploy/SKILL.md` references the resolver as the single way to compute peer FQDNs (even if SKILL.md only documents it; the harness behavior must consume it).
- [ ] No regressions: `scripts/device-health-check.sh virtual-smoker 3` and `scripts/deployment-health-check.sh smoker-dev-cloud-1` both still pass.

---

Generated by `/team-pickup` at 2026-05-05T13:10:00Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwzC6NLJxqLfEmoDqEY4hS)_