### PR TITLE
Closes #188: Tailscale persistent DNS — admin global nameservers + Ansible assertion + docs

### DIFF
--- a/infra/proxmox/ansible/README.md
+++ b/infra/proxmox/ansible/README.md
@@ -159,6 +159,25 @@ Tailscale Mesh Network
    - Set expiration to "90 days" or longer
    - Add tags if using ACLs: `tag:server`, `tag:runner`, `tag:device`, `tag:production`, `tag:development`
 
+### Tailscale Admin DNS Configuration (Required)
+
+Before running any playbook, configure global nameservers in the Tailscale admin console:
+
+1. Go to <https://login.tailscale.com/admin/dns>
+2. Under **Global nameservers**, add:
+   - `1.1.1.1` (Cloudflare)
+   - `8.8.8.8` (Google)
+3. Ensure **Override local DNS** is enabled so `accept-dns=true` forwards unknown queries upstream
+
+**Why this is mandatory for Proxmox LXCs**: `chattr +i /etc/resolv.conf` is blocked
+inside unprivileged LXC containers, so DNS cannot be locked in-container. Without
+global nameservers set in the admin console, Docker image pulls (`registry-1.docker.io`)
+and other public DNS queries will break after `tailscaled` restarts or LXC reboots.
+
+The tailscale Ansible role asserts this is configured (`tailscale dns status` must
+show at least one resolver). The playbook will fail with an actionable error message
+if the admin console DNS is not set up.
+
 ### Setup Tailscale Network
 
 #### Option 1: Configure with Ansible (Recommended)

--- a/infra/proxmox/ansible/roles/tailscale/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/tailscale/tasks/main.yml
@@ -121,3 +121,23 @@
   ansible.builtin.debug:
     msg: "{{ tailscale_final_status.stdout_lines }}"
   when: tailscale_final_status.rc == 0
+
+- name: Check Tailscale DNS resolver status
+  ansible.builtin.command: tailscale dns status
+  register: tailscale_dns_status
+  changed_when: false
+  failed_when: false
+
+- name: Assert Tailscale admin DNS global nameservers are configured
+  ansible.builtin.assert:
+    that:
+      - tailscale_dns_status.rc == 0
+      - tailscale_dns_status.stdout | regex_search('[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
+    fail_msg: >-
+      Tailscale admin DNS global nameservers are not configured on {{ inventory_hostname }}.
+      DNS resolution will fail after tailscaled restarts or LXC reboots.
+      Fix: go to https://login.tailscale.com/admin/dns and add global nameservers
+      1.1.1.1 and 8.8.8.8. Note: chattr +i /etc/resolv.conf is blocked inside
+      Proxmox LXCs, so the admin console fix is mandatory — local /etc/resolv.conf
+      edits will not persist.
+    success_msg: "Tailscale DNS resolvers are configured on {{ inventory_hostname }}"


### PR DESCRIPTION
## Summary

Add DNS resolver assertion to the Tailscale Ansible role that runs `tailscale dns status` and fails the playbook with an actionable message if no global nameservers are configured in the Tailscale admin console. Document the requirement in `README.md`, including the Proxmox LXC `chattr +i` limitation that makes the admin-side fix mandatory.

## Closes

Closes #188 — Tailscale persistent DNS — admin global nameservers + Ansible assertion + docs

## Smoke

`smoke: SKIPPED — backend/frontend services not running on localhost and Playwright chromium not installed in sandbox`

## Manual verification

- [ ] Tailscale admin DNS (`https://login.tailscale.com/admin/dns`) lists `1.1.1.1` + `8.8.8.8` as global nameservers (HITL — operator action; verified by `tailscale dns status`).
- [ ] Ansible task in the relevant LXC role asserts `tailscale dns status` shows resolvers configured. Fails the playbook with an actionable message if missing.
- [ ] `infra/proxmox/ansible/README.md` documents the Tailscale admin DNS requirement, calls out `chattr +i /etc/resolv.conf` is blocked inside Proxmox LXCs (so admin-side fix is mandatory), and removes any `--accept-dns=false` workaround references.
- [ ] After the admin change, fresh `pct exec <CTID> -- getent hosts registry-1.docker.io` succeeds on dev-cloud + virtual-smoker + runner LXCs without any manual resolv.conf edits.

---

Generated by `/team-pickup` at 2026-05-05T13:30:00Z

---
_Generated by [Claude Code](https://claude.ai/code/session_015dBycVB3c4r1VgCC74Qhyq)_