### PR TITLE
fix(ci): export VERSION + secrets in dev-deploy rollback step

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -313,9 +313,17 @@ jobs:
             set -e
             DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
             COMPOSE_FILE="${{ env.COMPOSE_FILE }}"
-            
+
             cd "${DEPLOY_DIR}" || { echo "❌ Deployment directory not found: ${DEPLOY_DIR}"; exit 1; }
-            
+
+            export VERSION="${{ env.VERSION }}"
+            export VAPID_PRIVATE_KEY='${{ secrets.VAPID_PRIVATE_KEY }}'
+            export VAPID_PUBLIC_KEY='${{ secrets.VAPID_PUBLIC_KEY }}'
+            export MONGO_ROOT_USER=admin
+            export MONGO_ROOT_PASSWORD='${{ secrets.MONGO_ROOT_PASSWORD }}'
+            export MONGO_APP_PASSWORD='${{ secrets.MONGO_APP_PASSWORD }}'
+            export ENCODED_MONGO_APP_PASSWORD='${{ env.ENCODED_MONGO_APP_PASSWORD }}'
+
             if [ -f "./scripts/rollback.sh" ]; then
               COMPOSE_FILE="${COMPOSE_FILE}" ./scripts/rollback.sh
             else


### PR DESCRIPTION
## Summary
- Rollback step in `.github/workflows/dev-deploy.yml` ran `docker compose up -d --force-recreate` without exporting `VERSION`, so compose substituted `${VERSION:-latest}` and tried to pull `benjr70/smart-smoker-*:latest` — a tag that's never published (only `:latest-dev` and `:nightly`). Rollback exited 1.
- Mirror the env exports from the `Deploy to dev-cloud` step (`VERSION`, `VAPID_*`, `MONGO_*`, `ENCODED_MONGO_APP_PASSWORD`) inside the rollback's remote SSH script so both branches (scripts/rollback.sh + inline compose up) recreate containers with the correct image tag.
- Surfaced by Dev Deploy run [25586197692](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/25586197692) on master after PR #205. The primary failure in that run was a Tailscale peer-name mismatch (`smoker-dev-cloud` vs. `smoker-dev-cloud-1`) tripping the health check; the broken rollback then masked the underlying cause. Hostname mismatch is being addressed separately by renaming the Tailscale machine in the admin console (no code change needed).

## Test plan
- [ ] Wait for Tailscale machine rename `smoker-dev-cloud` → `smoker-dev-cloud-1` to land.
- [ ] Merge this PR.
- [ ] `gh workflow run dev-deploy.yml --ref master`.
- [ ] Confirm `Verify deployment health` passes (resolver finds the renamed peer) and `Rollback on failure` is skipped (`steps.health_check.outcome != 'failure'`).
- [ ] Optional regression: temporarily fail the health check (e.g. workflow_dispatch with a bogus host) on a throwaway branch and confirm the rollback step now pulls `:nightly` rather than `:latest`. Skip if not worth the runner time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)