### PR TITLE
fix(ci): pass dev-cloud FQDN to deployment-health-check

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -44,16 +44,19 @@ jobs:
         id: vars
         run: |
           DEV_HOST="${{ vars.DEV_CLOUD_HOST || 'smoker-dev-cloud-1' }}"
+          DEV_FQDN="${{ vars.DEV_CLOUD_FQDN || 'smoker-dev-cloud-1.tail74646.ts.net' }}"
           DEPLOY_DIR="/opt/smart-smoker-dev"
           COMPOSE_FILE="cloud.docker-compose.yml"
           VERSION="nightly"
 
           echo "DEV_HOST=${DEV_HOST}" >> $GITHUB_ENV
+          echo "DEV_FQDN=${DEV_FQDN}" >> $GITHUB_ENV
           echo "DEPLOY_DIR=${DEPLOY_DIR}" >> $GITHUB_ENV
           echo "COMPOSE_FILE=${COMPOSE_FILE}" >> $GITHUB_ENV
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
           echo "Deployment target: ${DEV_HOST}"
+          echo "FQDN target: ${DEV_FQDN}"
           echo "Deployment directory: ${DEPLOY_DIR}"
           echo "Version: ${VERSION}"
 
@@ -293,8 +296,8 @@ jobs:
       - name: Verify deployment health
         id: health_check
         run: |
-          echo "Running health checks on ${DEV_HOST}..."
-          if ./scripts/deployment-health-check.sh ${DEV_HOST} 3; then
+          echo "Running health checks on ${DEV_FQDN}..."
+          if ./scripts/deployment-health-check.sh "${DEV_FQDN}" 3; then
             echo "✅ All health checks passed"
             echo "health_status=success" >> $GITHUB_OUTPUT
           else
@@ -345,7 +348,7 @@ jobs:
 
           # Verify rollback success
           echo "Verifying rollback..."
-          if ./scripts/deployment-health-check.sh ${DEV_HOST} 1; then
+          if ./scripts/deployment-health-check.sh "${DEV_FQDN}" 1; then
             echo "✅ Rollback successful, system restored"
             echo "rollback_status=success" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
- `scripts/smoke/resolve-host.ts` does strict `HostName === input` matching against `tailscale status --json`. The Tailscale peer's `HostName` is `smoker-dev-cloud` (no `-1` suffix), so matching against the canonical `smoker-dev-cloud-1` exits 1 and tanks `Verify deployment health` — and the rollback's verify call too.
- MagicDNS for `smoker-dev-cloud-1.tail74646.ts.net` resolves fine. The smoke step in run [25628730254](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/25628730254/job/75228419714) PASSed `health` and `ready` against that exact URL — only `resolve-host.ts`'s peer-name lookup rejects it.
- `resolve-host.ts` case (a) short-circuits when input contains `.ts.net` and returns it as-is. Plumbing a new `DEV_FQDN` env (sourced from existing `vars.DEV_CLOUD_FQDN` with the canonical `-1` fallback that `publish.yml` already uses) and passing it to both health-check invocations (primary + rollback verify) sidesteps the broken peer match. Curl then probes the same URLs the smoke step just validated.
- `DEV_HOST` (short name) stays in place for SSH-based steps — those have worked end-to-end every run. `resolve-host.ts` strict matching is intentional per PRD #187/#189 invariant and stays unchanged. AC6 hostname guard still passes — the suffixed `-1.tail74646.ts.net` literal lives inside a `vars.DEV_CLOUD_FQDN` fallback.

## Test plan
- [ ] Merge.
- [ ] `gh workflow run dev-deploy.yml --ref master`.
- [ ] Confirm log shows `Resolving Tailscale FQDN for smoker-dev-cloud-1.tail74646.ts.net...` followed by case-(a) immediate return, then `Backend API is healthy` + `Frontend is healthy`.
- [ ] Confirm `Rollback on failure` is **skipped** (`steps.health_check.outcome != 'failure'`).
- [ ] `/verify-deploy` to confirm end-to-end frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)