### PR TITLE
Closes #190: Self-healing GitHub Actions runner — DNS guardrail + auto re-register

### DIFF
--- a/infra/proxmox/ansible/README.md
+++ b/infra/proxmox/ansible/README.md
@@ -587,6 +587,110 @@ After Ansible configuration:
 4. ⏭️ Deploy applications via GitHub Actions
 5. ⏭️ Migrate production database
 
+## Self-Healing: DNS Guardrail
+
+The `github-runner` role deploys a DNS guardrail that blocks the runner service
+from starting when DNS is broken, and repairs it automatically.
+
+**How it works:**
+
+1. A drop-in `dns-guard.conf` is installed under the runner's systemd service
+   drop-in directory (e.g. `actions.runner.<name>.service.d/`). It adds
+   `ExecStartPre=/usr/local/bin/runner-dns-guard.sh`.
+2. On every start attempt, `runner-dns-guard.sh` probes
+   `pipelinesghubeus5.actions.githubusercontent.com` via `getent hosts`.
+3. If the probe fails, it restarts `tailscaled`, rewrites `/etc/resolv.conf`
+   from `/etc/resolv.conf.template` (1.1.1.1 + 8.8.8.8), then re-checks.
+4. If DNS is still broken, the script exits non-zero and the runner service
+   does not start.
+5. A `runner-dns-guard.timer` also runs the script every 10 minutes
+   independently, so DNS is repaired even if the runner is not actively
+   restarting.
+
+**Key files:**
+- `/usr/local/bin/runner-dns-guard.sh` — probe + remediation script
+- `/etc/resolv.conf.template` — known-good nameservers (1.1.1.1, 8.8.8.8, 8.8.4.4)
+- `/var/log/runner-dns-guard.log` — guard log
+
+## Self-Healing: Re-registration Watchdog
+
+When a GitHub Actions runner's registration is revoked (e.g. after a long
+offline period), the runner log contains "registration deleted from server".
+The watchdog detects this and re-registers automatically using a stored PAT.
+
+**How it works:**
+
+1. A systemd path unit `runner-reregister-watchdog.path` monitors
+   `<install_dir>/_diag/` for changes (new log files written by the runner).
+2. When the path changes, `runner-reregister-watchdog.service` fires.
+3. `runner-reregister-watchdog.sh` checks the latest `Runner_*.log` for
+   "registration deleted from server".
+4. If found, it reads the PAT from `/etc/actions-runner/.token`, POSTs to
+   `https://api.github.com/repos/<repo>/actions/runners/registration-token`
+   to get a fresh token, then runs `./config.sh --replace`.
+5. The runner service is restarted automatically.
+
+**Key files:**
+- `/usr/local/bin/runner-reregister-watchdog.sh` — watchdog script
+- `/etc/actions-runner/.token` — PAT file (mode 0600, owned by runner user)
+- `/var/log/runner-reregister-watchdog.log` — watchdog log
+
+## PAT Rotation Procedure
+
+The GitHub PAT stored at `/etc/actions-runner/.token` grants the runner the
+ability to generate fresh registration tokens. It must be rotated when it
+expires or is compromised.
+
+**Storage:**
+- Path: `/etc/actions-runner/.token`
+- Mode: `0600`
+- Owner: `{{ github_runner_user }}` (default: `runner`)
+
+**Rotation steps:**
+1. Generate a new PAT in GitHub → Settings → Developer settings → Personal
+   access tokens. Required scope: `repo` (for `actions/runners` API).
+2. Update the secret in your inventory/vault:
+   ```
+   github_runner_pat: "<new-pat>"
+   ```
+3. Re-run the playbook with the `self-healing` tag:
+   ```bash
+   ansible-playbook playbooks/github-runner.yml --tags self-healing -e "github_runner_pat=<new-pat>"
+   ```
+   This overwrites `/etc/actions-runner/.token` with mode 0600 (`no_log: true`).
+4. Verify the file on the runner host:
+   ```bash
+   ssh root@<runner-host> "ls -la /etc/actions-runner/.token && wc -c /etc/actions-runner/.token"
+   ```
+5. Revoke the old PAT in GitHub settings.
+
+**Note:** The file `/etc/github-runner/pat` (used by the older
+`runner-health-check.sh`) is a separate artifact. If both self-healing
+mechanisms are active, rotate both files.
+
+## Zombie Service Cleanup Runbook
+
+If the runner fails to re-register or the role re-apply fails with "unit
+already loaded", stale systemd service files from old runner registrations
+may be present. The role cleans these up idempotently on every run.
+
+**Known zombie service names:**
+- `smart-smoker-runner-1.service`
+- `smoker-runner-1.service`
+
+**Known blocker:**
+- `.runner_migrated` marker in the runner install directory blocks `./svc.sh
+  install` from creating a new service. The role removes it automatically.
+
+**Manual cleanup (if role re-apply is not possible):**
+```bash
+systemctl stop smart-smoker-runner-1.service smoker-runner-1.service 2>/dev/null || true
+rm -f /etc/systemd/system/smart-smoker-runner-1.service
+rm -f /etc/systemd/system/smoker-runner-1.service
+rm -f <install_dir>/.runner_migrated
+systemctl daemon-reload
+```
+
 ## Support
 
 For issues or questions:

--- a/infra/proxmox/ansible/roles/github-runner/defaults/main.yml
+++ b/infra/proxmox/ansible/roles/github-runner/defaults/main.yml
@@ -37,3 +37,9 @@ github_runner_ephemeral: false
 github_runner_log_retention_days: 7
 github_runner_disk_warn_percent: 80
 github_runner_run_initial_cleanup: false
+
+# DNS guardrail — host to probe before runner starts
+github_runner_dns_probe_host: pipelinesghubeus5.actions.githubusercontent.com
+
+# PAT file path on disk for self-healing units (mode 0600, owned by runner user)
+github_runner_pat_file: /etc/actions-runner/.token

--- a/infra/proxmox/ansible/roles/github-runner/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/github-runner/tasks/main.yml
@@ -402,3 +402,203 @@
   when: github_runner_pat != ""
   tags:
     - self-healing
+
+# =============================================================================
+# Zombie Service Cleanup
+# =============================================================================
+
+- name: Remove stale zombie runner service files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/systemd/system/smart-smoker-runner-1.service
+    - /etc/systemd/system/smoker-runner-1.service
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - cleanup
+
+- name: Remove .runner_migrated marker that blocks re-config
+  ansible.builtin.file:
+    path: "{{ github_runner_install_dir }}/.runner_migrated"
+    state: absent
+  tags:
+    - self-healing
+    - cleanup
+
+# =============================================================================
+# DNS Guardrail
+# =============================================================================
+
+- name: Deploy known-good resolv.conf template
+  ansible.builtin.template:
+    src: resolv.conf.j2
+    dest: /etc/resolv.conf.template
+    owner: root
+    group: root
+    mode: "0644"
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Deploy DNS guardrail script
+  ansible.builtin.template:
+    src: runner-dns-guard.sh.j2
+    dest: /usr/local/bin/runner-dns-guard.sh
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Deploy DNS guardrail systemd service
+  ansible.builtin.template:
+    src: runner-dns-guard.service.j2
+    dest: /etc/systemd/system/runner-dns-guard.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Deploy DNS guardrail systemd timer
+  ansible.builtin.template:
+    src: runner-dns-guard.timer.j2
+    dest: /etc/systemd/system/runner-dns-guard.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Find runner systemd service name for drop-in
+  ansible.builtin.find:
+    paths: /etc/systemd/system
+    patterns: "actions.runner.*.service"
+    file_type: file
+  register: runner_service_files
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Create drop-in directory for runner service DNS guard
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ item.path | basename }}.d"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop: "{{ runner_service_files.files }}"
+  when: runner_service_files.files | length > 0
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Deploy DNS guard drop-in for runner service
+  ansible.builtin.template:
+    src: runner-dns-guard-dropin.conf.j2
+    dest: "/etc/systemd/system/{{ item.path | basename }}.d/dns-guard.conf"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ runner_service_files.files }}"
+  when: runner_service_files.files | length > 0
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Enable and start DNS guardrail timer
+  ansible.builtin.systemd:
+    name: runner-dns-guard.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+  tags:
+    - self-healing
+    - dns-guard
+
+# =============================================================================
+# Re-registration Watchdog
+# =============================================================================
+
+- name: Create /etc/actions-runner directory for PAT
+  ansible.builtin.file:
+    path: /etc/actions-runner
+    state: directory
+    owner: "{{ github_runner_user }}"
+    group: "{{ github_runner_user }}"
+    mode: "0700"
+  when: github_runner_pat != ""
+  tags:
+    - self-healing
+    - reregister
+
+- name: Deploy PAT to /etc/actions-runner/.token
+  ansible.builtin.copy:
+    content: "{{ github_runner_pat }}"
+    dest: "{{ github_runner_pat_file }}"
+    owner: "{{ github_runner_user }}"
+    group: "{{ github_runner_user }}"
+    mode: "0600"
+  when: github_runner_pat != ""
+  no_log: true
+  tags:
+    - self-healing
+    - reregister
+
+- name: Deploy re-registration watchdog script
+  ansible.builtin.template:
+    src: runner-reregister-watchdog.sh.j2
+    dest: /usr/local/bin/runner-reregister-watchdog.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when: github_runner_pat != ""
+  tags:
+    - self-healing
+    - reregister
+
+- name: Deploy re-registration watchdog systemd service
+  ansible.builtin.template:
+    src: runner-reregister-watchdog.service.j2
+    dest: /etc/systemd/system/runner-reregister-watchdog.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: github_runner_pat != ""
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - reregister
+
+- name: Deploy re-registration watchdog systemd path unit
+  ansible.builtin.template:
+    src: runner-reregister-watchdog.path.j2
+    dest: /etc/systemd/system/runner-reregister-watchdog.path
+    owner: root
+    group: root
+    mode: "0644"
+  when: github_runner_pat != ""
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - reregister
+
+- name: Enable and start re-registration watchdog path unit
+  ansible.builtin.systemd:
+    name: runner-reregister-watchdog.path
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: github_runner_pat != ""
+  tags:
+    - self-healing
+    - reregister

--- a/infra/proxmox/ansible/roles/github-runner/templates/resolv.conf.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/resolv.conf.j2
@@ -1,0 +1,5 @@
+# /etc/resolv.conf.template — known-good fallback
+# Managed by Ansible - Do not edit manually
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+nameserver 8.8.4.4

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-dns-guard-dropin.conf.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-dns-guard-dropin.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/local/bin/runner-dns-guard.sh

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-dns-guard.service.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-dns-guard.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=GitHub Actions Runner DNS Guardrail
+After=network-online.target tailscaled.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/runner-dns-guard.sh
+User=root
+StandardOutput=journal
+StandardError=journal
+RemainAfterExit=no

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-dns-guard.sh.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-dns-guard.sh.j2
@@ -1,0 +1,56 @@
+#!/bin/bash
+# GitHub Actions Runner DNS Guardrail
+# Managed by Ansible - Do not edit manually
+#
+# Verifies pipelinesghubeus5.actions.githubusercontent.com resolves before
+# the runner service starts. If DNS is broken, restarts tailscaled and
+# rewrites /etc/resolv.conf from the known-good template, then re-checks.
+# Exits non-zero if DNS is still broken after remediation.
+
+set -euo pipefail
+
+LOG_TAG="runner-dns-guard"
+DNS_PROBE_HOST="{{ github_runner_dns_probe_host }}"
+RESOLV_TEMPLATE="/etc/resolv.conf.template"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$LOG_TAG] $*" | tee -a /var/log/runner-dns-guard.log
+}
+
+check_dns() {
+    timeout 5 getent hosts "$DNS_PROBE_HOST" > /dev/null 2>&1
+}
+
+if check_dns; then
+    log "DNS OK: $DNS_PROBE_HOST resolves"
+    exit 0
+fi
+
+log "DNS FAIL: $DNS_PROBE_HOST does not resolve — starting remediation"
+
+# Step 1: restart tailscaled
+if systemctl is-active tailscaled > /dev/null 2>&1; then
+    log "Restarting tailscaled..."
+    systemctl restart tailscaled
+    sleep 5
+fi
+
+# Step 2: rewrite resolv.conf from known-good template
+if [ -f "$RESOLV_TEMPLATE" ]; then
+    log "Rewriting /etc/resolv.conf from $RESOLV_TEMPLATE"
+    cp "$RESOLV_TEMPLATE" /etc/resolv.conf
+else
+    log "Template $RESOLV_TEMPLATE missing — writing fallback nameservers"
+    printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /etc/resolv.conf
+fi
+
+sleep 3
+
+# Step 3: re-check
+if check_dns; then
+    log "DNS OK after remediation: $DNS_PROBE_HOST resolves"
+    exit 0
+fi
+
+log "ERROR: DNS still broken after remediation — runner will not start"
+exit 1

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-dns-guard.timer.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-dns-guard.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=GitHub Actions Runner DNS Guardrail Timer
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=10min
+RandomizedDelaySec=15
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-reregister-watchdog.path.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-reregister-watchdog.path.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=GitHub Actions Runner Re-registration Watchdog Path Monitor
+
+[Path]
+PathModified={{ github_runner_install_dir }}/_diag
+Unit=runner-reregister-watchdog.service
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-reregister-watchdog.service.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-reregister-watchdog.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=GitHub Actions Runner Re-registration Watchdog
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/runner-reregister-watchdog.sh
+User=root
+StandardOutput=journal
+StandardError=journal
+RemainAfterExit=no

--- a/infra/proxmox/ansible/roles/github-runner/templates/runner-reregister-watchdog.sh.j2
+++ b/infra/proxmox/ansible/roles/github-runner/templates/runner-reregister-watchdog.sh.j2
@@ -1,0 +1,116 @@
+#!/bin/bash
+# GitHub Actions Runner Re-registration Watchdog
+# Managed by Ansible - Do not edit manually
+#
+# Triggered by systemd path unit when _diag/ changes.
+# Checks runner log for "registration deleted from server" and,
+# if found, fetches a fresh registration token via GitHub API and
+# runs config.sh --replace to re-register without operator intervention.
+
+set -euo pipefail
+
+RUNNER_DIR="{{ github_runner_install_dir }}"
+RUNNER_USER="{{ github_runner_user }}"
+GITHUB_REPO="{{ github_repository }}"
+PAT_FILE="/etc/actions-runner/.token"
+LOG_TAG="runner-reregister-watchdog"
+LOCK_FILE="/tmp/runner-reregister.lock"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$LOG_TAG] $*" | tee -a /var/log/runner-reregister-watchdog.log
+}
+
+# Guard: only one instance at a time
+if [ -f "$LOCK_FILE" ]; then
+    log "Lock $LOCK_FILE exists — another instance running, exiting"
+    exit 0
+fi
+touch "$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
+
+# Pre-flight
+if [ ! -f "$RUNNER_DIR/config.sh" ]; then
+    log "Runner not installed at $RUNNER_DIR, skipping"
+    exit 0
+fi
+
+if [ ! -f "$PAT_FILE" ]; then
+    log "PAT file not found at $PAT_FILE, cannot auto-register"
+    exit 0
+fi
+
+PAT=$(cat "$PAT_FILE")
+if [ -z "$PAT" ]; then
+    log "PAT file is empty, cannot auto-register"
+    exit 0
+fi
+
+# Check recent runner logs for "registration deleted from server"
+DIAG_DIR="$RUNNER_DIR/_diag"
+if [ ! -d "$DIAG_DIR" ]; then
+    log "Diag directory $DIAG_DIR not found, skipping"
+    exit 0
+fi
+
+LATEST_LOG=$(find "$DIAG_DIR" -name 'Runner_*.log' -newer "$LOCK_FILE" -print 2>/dev/null | sort | tail -1)
+if [ -z "$LATEST_LOG" ]; then
+    LATEST_LOG=$(find "$DIAG_DIR" -name 'Runner_*.log' -print 2>/dev/null | sort | tail -1)
+fi
+
+if [ -z "$LATEST_LOG" ]; then
+    log "No Runner_*.log found in $DIAG_DIR, skipping"
+    exit 0
+fi
+
+if ! grep -q "registration deleted from server" "$LATEST_LOG" 2>/dev/null; then
+    log "No 'registration deleted' in $LATEST_LOG, skipping"
+    exit 0
+fi
+
+log "Detected 'registration deleted from server' — starting re-registration"
+
+# Fetch fresh token
+log "Requesting registration token from GitHub API..."
+RESPONSE=$(curl -sf -X POST \
+    -H "Authorization: Bearer $PAT" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/$GITHUB_REPO/actions/runners/registration-token" 2>&1) || {
+    log "ERROR: Failed to get registration token: $RESPONSE"
+    exit 1
+}
+
+TOKEN=$(echo "$RESPONSE" | jq -r '.token')
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+    log "ERROR: Could not parse token from API response"
+    exit 1
+fi
+
+log "Got token — running config.sh --replace"
+
+# Stop service temporarily
+SERVICE_FILE=$(find /etc/systemd/system -name "actions.runner.*.service" -print -quit 2>/dev/null || true)
+if [ -n "$SERVICE_FILE" ]; then
+    SERVICE_NAME=$(basename "$SERVICE_FILE" .service)
+    systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+fi
+
+# Re-configure
+cd "$RUNNER_DIR"
+sudo -u "$RUNNER_USER" ./config.sh \
+    --url "https://github.com/$GITHUB_REPO" \
+    --token "$TOKEN" \
+    --name "{{ github_runner_name }}" \
+    --labels "{{ github_runner_labels | join(',') }}" \
+    --work "{{ github_runner_work_directory }}" \
+    --replace \
+    --unattended
+
+chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR"
+
+# Restart service
+if [ -n "$SERVICE_FILE" ]; then
+    systemctl start "$SERVICE_NAME" || true
+fi
+
+log "Re-registration complete"

--- a/infra/proxmox/ansible/tests/test-github-runner-self-healing.sh
+++ b/infra/proxmox/ansible/tests/test-github-runner-self-healing.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+# Test: Self-healing GitHub Actions runner (DNS guardrail + re-register watchdog)
+# Issue #190
+# These are static analysis / syntax tests runnable without a live Ansible inventory.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANSIBLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROLE_DIR="$ANSIBLE_DIR/roles/github-runner"
+TEMPLATES_DIR="$ROLE_DIR/templates"
+TASKS_FILE="$ROLE_DIR/tasks/main.yml"
+DEFAULTS_FILE="$ROLE_DIR/defaults/main.yml"
+README_FILE="$ANSIBLE_DIR/README.md"
+
+TOTAL=0
+FAILURES=0
+
+pass() { echo -e "${GREEN}✓ PASS${NC}: $1"; TOTAL=$((TOTAL + 1)); }
+fail() { echo -e "${RED}✗ FAIL${NC}: $1"; TOTAL=$((TOTAL + 1)); FAILURES=$((FAILURES + 1)); }
+section() { echo -e "\n${YELLOW}▶ $1${NC}"; }
+
+# ---------------------------------------------------------------------------
+section "Template file existence"
+# ---------------------------------------------------------------------------
+
+for f in \
+    runner-dns-guard.sh.j2 \
+    runner-dns-guard.service.j2 \
+    runner-dns-guard.timer.j2 \
+    runner-dns-guard-dropin.conf.j2 \
+    resolv.conf.j2 \
+    runner-reregister-watchdog.sh.j2 \
+    runner-reregister-watchdog.service.j2 \
+    runner-reregister-watchdog.path.j2; do
+    if [ -f "$TEMPLATES_DIR/$f" ]; then
+        pass "template exists: $f"
+    else
+        fail "template missing: $f"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+section "Bash syntax check on shell templates"
+# ---------------------------------------------------------------------------
+
+for f in runner-dns-guard.sh.j2 runner-reregister-watchdog.sh.j2; do
+    # Strip Jinja2 to make bash -n happy: replace {{ ... }} with placeholder
+    STRIPPED=$(sed 's/{{[^}]*}}/PLACEHOLDER/g' "$TEMPLATES_DIR/$f")
+    if echo "$STRIPPED" | bash -n 2>/dev/null; then
+        pass "bash syntax OK: $f"
+    else
+        fail "bash syntax error: $f"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+section "systemd unit structure"
+# ---------------------------------------------------------------------------
+
+# DNS guard service has [Service] section with ExecStart
+if grep -q '^\[Service\]' "$TEMPLATES_DIR/runner-dns-guard.service.j2" \
+   && grep -q 'ExecStart=' "$TEMPLATES_DIR/runner-dns-guard.service.j2"; then
+    pass "runner-dns-guard.service.j2 has [Service] + ExecStart"
+else
+    fail "runner-dns-guard.service.j2 missing [Service] or ExecStart"
+fi
+
+# DNS guard timer has [Timer] and [Install]
+if grep -q '^\[Timer\]' "$TEMPLATES_DIR/runner-dns-guard.timer.j2" \
+   && grep -q '^\[Install\]' "$TEMPLATES_DIR/runner-dns-guard.timer.j2"; then
+    pass "runner-dns-guard.timer.j2 has [Timer] + [Install]"
+else
+    fail "runner-dns-guard.timer.j2 missing [Timer] or [Install]"
+fi
+
+# Drop-in has ExecStartPre
+if grep -q 'ExecStartPre=' "$TEMPLATES_DIR/runner-dns-guard-dropin.conf.j2"; then
+    pass "runner-dns-guard-dropin.conf.j2 has ExecStartPre"
+else
+    fail "runner-dns-guard-dropin.conf.j2 missing ExecStartPre"
+fi
+
+# Path unit has [Path] with PathModified
+if grep -q '^\[Path\]' "$TEMPLATES_DIR/runner-reregister-watchdog.path.j2" \
+   && grep -q 'PathModified=' "$TEMPLATES_DIR/runner-reregister-watchdog.path.j2"; then
+    pass "runner-reregister-watchdog.path.j2 has [Path] + PathModified"
+else
+    fail "runner-reregister-watchdog.path.j2 missing [Path] or PathModified"
+fi
+
+# Watchdog service has Type=oneshot
+if grep -q 'Type=oneshot' "$TEMPLATES_DIR/runner-reregister-watchdog.service.j2"; then
+    pass "runner-reregister-watchdog.service.j2 has Type=oneshot"
+else
+    fail "runner-reregister-watchdog.service.j2 missing Type=oneshot"
+fi
+
+# ---------------------------------------------------------------------------
+section "Script safety checks"
+# ---------------------------------------------------------------------------
+
+# DNS guard uses getent hosts (not nslookup)
+if grep -q 'getent hosts' "$TEMPLATES_DIR/runner-dns-guard.sh.j2"; then
+    pass "runner-dns-guard.sh.j2 uses getent hosts"
+else
+    fail "runner-dns-guard.sh.j2 should use getent hosts"
+fi
+
+# DNS guard restarts tailscaled
+if grep -q 'tailscaled' "$TEMPLATES_DIR/runner-dns-guard.sh.j2"; then
+    pass "runner-dns-guard.sh.j2 references tailscaled"
+else
+    fail "runner-dns-guard.sh.j2 missing tailscaled restart"
+fi
+
+# DNS guard rewrites resolv.conf from template
+if grep -q 'resolv.conf.template' "$TEMPLATES_DIR/runner-dns-guard.sh.j2"; then
+    pass "runner-dns-guard.sh.j2 uses resolv.conf.template"
+else
+    fail "runner-dns-guard.sh.j2 does not reference resolv.conf.template"
+fi
+
+# Watchdog checks for "registration deleted from server"
+if grep -q 'registration deleted from server' "$TEMPLATES_DIR/runner-reregister-watchdog.sh.j2"; then
+    pass "runner-reregister-watchdog.sh.j2 checks for 'registration deleted from server'"
+else
+    fail "runner-reregister-watchdog.sh.j2 missing 'registration deleted' check"
+fi
+
+# Watchdog uses PAT file path variable
+if grep -q '/etc/actions-runner/.token' "$TEMPLATES_DIR/runner-reregister-watchdog.sh.j2"; then
+    pass "runner-reregister-watchdog.sh.j2 uses /etc/actions-runner/.token"
+else
+    fail "runner-reregister-watchdog.sh.j2 missing PAT file path"
+fi
+
+# Watchdog runs config.sh --replace
+if grep -q '\-\-replace' "$TEMPLATES_DIR/runner-reregister-watchdog.sh.j2"; then
+    pass "runner-reregister-watchdog.sh.j2 runs config.sh --replace"
+else
+    fail "runner-reregister-watchdog.sh.j2 missing --replace flag"
+fi
+
+# Watchdog has lock file guard (prevents parallel execution)
+if grep -q 'LOCK_FILE' "$TEMPLATES_DIR/runner-reregister-watchdog.sh.j2"; then
+    pass "runner-reregister-watchdog.sh.j2 has lock file guard"
+else
+    fail "runner-reregister-watchdog.sh.j2 missing lock file guard"
+fi
+
+# ---------------------------------------------------------------------------
+section "defaults/main.yml new variables"
+# ---------------------------------------------------------------------------
+
+if grep -q 'github_runner_dns_probe_host' "$DEFAULTS_FILE"; then
+    pass "defaults/main.yml has github_runner_dns_probe_host"
+else
+    fail "defaults/main.yml missing github_runner_dns_probe_host"
+fi
+
+if grep -q 'github_runner_pat_file' "$DEFAULTS_FILE"; then
+    pass "defaults/main.yml has github_runner_pat_file"
+else
+    fail "defaults/main.yml missing github_runner_pat_file"
+fi
+
+if grep -q '/etc/actions-runner/.token' "$DEFAULTS_FILE"; then
+    pass "defaults/main.yml github_runner_pat_file points to /etc/actions-runner/.token"
+else
+    fail "defaults/main.yml github_runner_pat_file wrong value"
+fi
+
+# ---------------------------------------------------------------------------
+section "tasks/main.yml — zombie cleanup + new units"
+# ---------------------------------------------------------------------------
+
+if grep -q 'smart-smoker-runner-1' "$TASKS_FILE"; then
+    pass "tasks/main.yml removes smart-smoker-runner-1"
+else
+    fail "tasks/main.yml missing smart-smoker-runner-1 cleanup"
+fi
+
+if grep -q 'smoker-runner-1' "$TASKS_FILE"; then
+    pass "tasks/main.yml removes smoker-runner-1"
+else
+    fail "tasks/main.yml missing smoker-runner-1 cleanup"
+fi
+
+if grep -q '.runner_migrated' "$TASKS_FILE"; then
+    pass "tasks/main.yml removes .runner_migrated"
+else
+    fail "tasks/main.yml missing .runner_migrated cleanup"
+fi
+
+if grep -q 'runner-dns-guard.timer' "$TASKS_FILE"; then
+    pass "tasks/main.yml enables runner-dns-guard.timer"
+else
+    fail "tasks/main.yml missing runner-dns-guard.timer"
+fi
+
+if grep -q 'runner-reregister-watchdog.path' "$TASKS_FILE"; then
+    pass "tasks/main.yml enables runner-reregister-watchdog.path"
+else
+    fail "tasks/main.yml missing runner-reregister-watchdog.path"
+fi
+
+if grep -q 'runner-dns-guard-dropin' "$TASKS_FILE"; then
+    pass "tasks/main.yml deploys dns-guard drop-in"
+else
+    fail "tasks/main.yml missing dns-guard drop-in deployment"
+fi
+
+if grep -q 'resolv.conf.template' "$TASKS_FILE"; then
+    pass "tasks/main.yml deploys resolv.conf.template"
+else
+    fail "tasks/main.yml missing resolv.conf.template deployment"
+fi
+
+# PAT task uses no_log and correct mode
+# Verify no_log: true appears within 20 lines after the PAT deploy task name
+PAT_LINE=$(grep -n 'Deploy PAT to /etc/actions-runner' "$TASKS_FILE" | head -1 | cut -d: -f1)
+if [ -n "$PAT_LINE" ]; then
+    PAT_TASK_BLOCK=$(sed -n "${PAT_LINE},$((PAT_LINE + 20))p" "$TASKS_FILE")
+    if echo "$PAT_TASK_BLOCK" | grep -q 'no_log: true'; then
+        pass "PAT deploy task uses no_log: true"
+    else
+        fail "PAT deploy task missing no_log: true"
+    fi
+    if echo "$PAT_TASK_BLOCK" | grep -q '"0600"'; then
+        pass "PAT deploy task sets mode 0600"
+    else
+        fail "PAT deploy task missing mode 0600"
+    fi
+else
+    fail "PAT deploy task not found in tasks/main.yml"
+    fail "PAT deploy task mode check skipped"
+fi
+
+# ---------------------------------------------------------------------------
+section "README.md documentation"
+# ---------------------------------------------------------------------------
+
+for section_name in \
+    "Self-Healing: DNS Guardrail" \
+    "Self-Healing: Re-registration Watchdog" \
+    "PAT Rotation Procedure" \
+    "Zombie Service Cleanup Runbook"; do
+    if grep -q "## $section_name" "$README_FILE"; then
+        pass "README has section: $section_name"
+    else
+        fail "README missing section: $section_name"
+    fi
+done
+
+if grep -q '/etc/actions-runner/.token' "$README_FILE"; then
+    pass "README documents /etc/actions-runner/.token path"
+else
+    fail "README missing /etc/actions-runner/.token"
+fi
+
+if grep -q 'smart-smoker-runner-1' "$README_FILE"; then
+    pass "README mentions smart-smoker-runner-1 zombie"
+else
+    fail "README missing smart-smoker-runner-1 in runbook"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $((TOTAL - FAILURES))/$TOTAL passed"
+if [ "$FAILURES" -eq 0 ]; then
+    echo -e "${GREEN}All tests passed${NC}"
+    exit 0
+else
+    echo -e "${RED}$FAILURES test(s) failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Add DNS guardrail (ExecStartPre + timer) that probes pipelinesghubeus5.actions.githubusercontent.com, restarts tailscaled and rewrites /etc/resolv.conf from template on failure. Add re-register watchdog (systemd path unit) that detects "registration deleted from server" in runner logs and re-configs via fresh API token. Clean up zombie service files. Document PAT rotation in README.

## Closes

Closes #190 — Self-healing GitHub Actions runner — DNS guardrail + auto re-register

## Smoke

\`smoke: SKIPPED — no smoke targets for Ansible-only change\`

## Manual verification

- [ ] DNS guardrail unit/timer: pre-start check → if `getent hosts pipelinesghubeus5.actions.githubusercontent.com` fails, restart `tailscaled`, rewrite `/etc/resolv.conf` from template, re-check; runner service does not start until DNS is healthy.
- [ ] Re-register guardrail unit/timer: tails the runner log, on "registration deleted" pulls a fresh registration token via `gh api` using the PAT in `/etc/actions-runner/.token` (0600, owned by runner user), runs `config.sh --replace`.
- [ ] Both units are owned by the runner Ansible role and applied idempotently.
- [ ] Reboot drill: `pct reboot 106` brings the runner back online with the GitHub Actions listener reachable, no manual steps. Workflow dispatched right after boot picks up on the runner.
- [ ] Two zombie service files (`smart-smoker-runner-1`, `smoker-runner-1`) and any `.runner_migrated` marker that blocks re-config are cleaned up by the role; runbook updated to call out the trap.
- [ ] PAT secret handling documented: rotation procedure + storage path + permissions in `infra/proxmox/ansible/README.md`.

---

Generated by `/team-pickup` at 2026-05-10T00:00:00Z