### PR TITLE
fix(ci): remove Docker check from runner-test workflow

### DIFF
--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -35,15 +35,6 @@ jobs:
           echo "Memory: $(free -h | grep Mem | awk '{print $2}')"
           echo "Disk: $(df -h / | tail -1 | awk '{print $2}')"
 
-      - name: Verify Docker installation
-        run: |
-          echo "=== Docker Version ==="
-          docker --version
-          docker compose version
-          echo ""
-          echo "=== Docker Status ==="
-          systemctl status docker --no-pager || true
-
       - name: Verify Terraform installation
         run: |
           echo "=== Terraform Version ==="
@@ -80,7 +71,6 @@ jobs:
           echo ""
           echo "Verified:"
           echo "  - Runner is online and accepting jobs"
-          echo "  - Docker is installed and operational"
           echo "  - Terraform is installed and functional"
           echo "  - Node.js/npm are available"
           echo "  - Terraform can initialize and validate"


### PR DESCRIPTION
## Summary

- Remove "Verify Docker installation" step from `runner-test.yml`
- Remove Docker from "Report success" verified list

Runner LXC (`proxmox` label) is a GitHub Actions executor / Terraform+Ansible host — Docker is intentionally absent. Step was failing with exit 127, blocking all downstream verification steps.

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch → "Test Self-Hosted Runner" should reach "Report success" with all steps green

🤖 Generated with [Claude Code](https://claude.com/claude-code)