### PR TITLE
fix(deploy): retry docker pull + dev-cloud DNS guardrail

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -219,8 +219,40 @@ jobs:
             export ENCODED_MONGO_APP_PASSWORD='${{ env.ENCODED_MONGO_APP_PASSWORD }}'
             
             echo "Pulling Docker images with version: ${VERSION}..."
-            docker compose -f "${COMPOSE_FILE}" pull
-            
+            DNS_PROBE_HOST="registry-1.docker.io"
+            MAX_ATTEMPTS=3
+            ATTEMPT=1
+            PULL_OK=0
+            while [ "${ATTEMPT}" -le "${MAX_ATTEMPTS}" ]; do
+              echo "[deploy] pull attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
+              if ! timeout 5 getent hosts "${DNS_PROBE_HOST}" > /dev/null 2>&1; then
+                echo "[deploy] DNS probe failed for ${DNS_PROBE_HOST}, remediating..."
+                if systemctl is-active tailscaled > /dev/null 2>&1; then
+                  echo "[deploy] restarting tailscaled"
+                  systemctl restart tailscaled || true
+                  sleep 5
+                fi
+                if [ ! -L /etc/resolv.conf ] && [ -w /etc/resolv.conf ]; then
+                  echo "[deploy] writing fallback nameservers to /etc/resolv.conf"
+                  printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /etc/resolv.conf
+                else
+                  echo "[deploy] /etc/resolv.conf is a symlink or not writable, skipping rewrite"
+                fi
+                sleep 3
+              fi
+              if docker compose -f "${COMPOSE_FILE}" pull; then
+                PULL_OK=1
+                break
+              fi
+              echo "[deploy] pull attempt ${ATTEMPT} failed"
+              ATTEMPT=$((ATTEMPT + 1))
+              [ "${ATTEMPT}" -le "${MAX_ATTEMPTS}" ] && sleep 15
+            done
+            if [ "${PULL_OK}" -ne 1 ]; then
+              echo "❌ docker compose pull failed after ${MAX_ATTEMPTS} attempts"
+              exit 1
+            fi
+
             echo "Stopping existing containers..."
             docker compose -f "${COMPOSE_FILE}" down || true
             

--- a/infra/proxmox/ansible/playbooks/setup-dev-cloud.yml
+++ b/infra/proxmox/ansible/playbooks/setup-dev-cloud.yml
@@ -14,6 +14,7 @@
     - cloud-app
     - backups
     - tailscale
+    - dns-guard
 
   post_tasks:
     - name: Display dev cloud setup summary

--- a/infra/proxmox/ansible/roles/dns-guard/defaults/main.yml
+++ b/infra/proxmox/ansible/roles/dns-guard/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# DNS guardrail role — probes a known-good host and remediates broken DNS.
+# Generic version of the github-runner role's guardrail; used by hosts that
+# depend on outbound DNS (e.g., dev-cloud pulling Docker images).
+
+# Host to probe before declaring DNS healthy.
+dns_guard_probe_host: registry-1.docker.io
+
+# Systemd unit name (without .service / .timer suffix).
+dns_guard_service_name: dns-guard
+
+# Path where the known-good resolv.conf fallback is stored.
+dns_guard_resolv_template_path: /etc/resolv.conf.template
+
+# Log tag used in /var/log/{{ dns_guard_service_name }}.log
+dns_guard_log_tag: dns-guard

--- a/infra/proxmox/ansible/roles/dns-guard/handlers/main.yml
+++ b/infra/proxmox/ansible/roles/dns-guard/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/infra/proxmox/ansible/roles/dns-guard/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/dns-guard/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+# Generic DNS guardrail — systemd timer + oneshot service that probes a
+# known-good host and remediates broken DNS (restart tailscaled, rewrite
+# /etc/resolv.conf from template).
+#
+# NOTE: The github-runner role ships its own copy with a runner-specific
+# systemd drop-in. This role intentionally omits that drop-in so it can be
+# applied to any host (dev-cloud, prod-cloud, etc.).
+
+- name: Deploy known-good resolv.conf template
+  ansible.builtin.template:
+    src: resolv.conf.j2
+    dest: "{{ dns_guard_resolv_template_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Deploy DNS guardrail script
+  ansible.builtin.template:
+    src: dns-guard.sh.j2
+    dest: "/usr/local/bin/{{ dns_guard_service_name }}.sh"
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Deploy DNS guardrail systemd service
+  ansible.builtin.template:
+    src: dns-guard.service.j2
+    dest: "/etc/systemd/system/{{ dns_guard_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Deploy DNS guardrail systemd timer
+  ansible.builtin.template:
+    src: dns-guard.timer.j2
+    dest: "/etc/systemd/system/{{ dns_guard_service_name }}.timer"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd daemon
+  tags:
+    - self-healing
+    - dns-guard
+
+- name: Enable and start DNS guardrail timer
+  ansible.builtin.systemd:
+    name: "{{ dns_guard_service_name }}.timer"
+    enabled: true
+    state: started
+    daemon_reload: true
+  tags:
+    - self-healing
+    - dns-guard

--- a/infra/proxmox/ansible/roles/dns-guard/templates/dns-guard.service.j2
+++ b/infra/proxmox/ansible/roles/dns-guard/templates/dns-guard.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=DNS Guardrail ({{ dns_guard_probe_host }})
+After=network-online.target tailscaled.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/{{ dns_guard_service_name }}.sh
+User=root
+StandardOutput=journal
+StandardError=journal
+RemainAfterExit=no

--- a/infra/proxmox/ansible/roles/dns-guard/templates/dns-guard.sh.j2
+++ b/infra/proxmox/ansible/roles/dns-guard/templates/dns-guard.sh.j2
@@ -1,0 +1,57 @@
+#!/bin/bash
+# DNS Guardrail (generic)
+# Managed by Ansible - Do not edit manually
+#
+# Verifies the configured probe host resolves. If DNS is broken,
+# restarts tailscaled and rewrites /etc/resolv.conf from the known-good
+# template, then re-checks. Exits non-zero if DNS is still broken.
+
+set -euo pipefail
+
+LOG_TAG="{{ dns_guard_log_tag }}"
+DNS_PROBE_HOST="{{ dns_guard_probe_host }}"
+RESOLV_TEMPLATE="{{ dns_guard_resolv_template_path }}"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$LOG_TAG] $*" | tee -a /var/log/{{ dns_guard_service_name }}.log
+}
+
+check_dns() {
+    timeout 5 getent hosts "$DNS_PROBE_HOST" > /dev/null 2>&1
+}
+
+if check_dns; then
+    log "DNS OK: $DNS_PROBE_HOST resolves"
+    exit 0
+fi
+
+log "DNS FAIL: $DNS_PROBE_HOST does not resolve — starting remediation"
+
+# Step 1: restart tailscaled
+if systemctl is-active tailscaled > /dev/null 2>&1; then
+    log "Restarting tailscaled..."
+    systemctl restart tailscaled
+    sleep 5
+fi
+
+# Step 2: rewrite resolv.conf from known-good template
+if [ -L /etc/resolv.conf ]; then
+    log "/etc/resolv.conf is a symlink — leaving it alone"
+elif [ -f "$RESOLV_TEMPLATE" ]; then
+    log "Rewriting /etc/resolv.conf from $RESOLV_TEMPLATE"
+    cp "$RESOLV_TEMPLATE" /etc/resolv.conf
+else
+    log "Template $RESOLV_TEMPLATE missing — writing fallback nameservers"
+    printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /etc/resolv.conf
+fi
+
+sleep 3
+
+# Step 3: re-check
+if check_dns; then
+    log "DNS OK after remediation: $DNS_PROBE_HOST resolves"
+    exit 0
+fi
+
+log "ERROR: DNS still broken after remediation"
+exit 1

--- a/infra/proxmox/ansible/roles/dns-guard/templates/dns-guard.timer.j2
+++ b/infra/proxmox/ansible/roles/dns-guard/templates/dns-guard.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=DNS Guardrail Timer ({{ dns_guard_probe_host }})
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=10min
+RandomizedDelaySec=15
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/proxmox/ansible/roles/dns-guard/templates/resolv.conf.j2
+++ b/infra/proxmox/ansible/roles/dns-guard/templates/resolv.conf.j2
@@ -1,0 +1,5 @@
+# {{ dns_guard_resolv_template_path }} — known-good fallback
+# Managed by Ansible - Do not edit manually
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+nameserver 8.8.4.4


### PR DESCRIPTION
## Summary
- Fixes [run 26698165857](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/26698165857/job/78686089952) where `deploy-dev-cloud` failed with `lookup registry-1.docker.io: i/o timeout` on `docker compose pull`.
- Wraps `docker compose pull` in a 3-attempt retry with DNS probe + inline remediation (restart `tailscaled`, rewrite `/etc/resolv.conf` fallback when not a symlink), 15s backoff between tries.
- Adds reusable `dns-guard` Ansible role (systemd timer + oneshot, `OnBootSec=30s`, `OnUnitActiveSec=10min`) mirroring the runner guardrail from #210, parameterized via `dns_guard_probe_host` (default `registry-1.docker.io`).
- Wires `dns-guard` into `setup-dev-cloud.yml` after `tailscale`.

Defense-in-depth: CI-side retry ships immediately; host-side guardrail prevents recurrence after the Ansible apply.

## Test plan
- [ ] Merge → confirm `dev-deploy.yml` reaches `Configure Tailscale Serve` step on master push.
- [ ] Apply role: `ansible-playbook -i infra/proxmox/ansible/inventory/hosts.yml infra/proxmox/ansible/playbooks/setup-dev-cloud.yml --tags dns-guard --limit smart-smoker-dev-cloud-1`.
- [ ] On dev-cloud host: `systemctl status dns-guard.timer dns-guard.service` shows timer active, service exited 0.
- [ ] `journalctl -u dns-guard.service --no-pager -n 20` shows `DNS OK: registry-1.docker.io resolves`.
- [ ] Negative test: temporarily clobber `/etc/resolv.conf` on dev-cloud, rerun `dev-deploy` from GH UI, verify retry logs `[deploy] DNS probe failed ... remediating...` and pull succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)