### PR TITLE
Closes #220: release.yml: remove prod-cloud rebuild/deploy path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,6 @@ on:
         type: boolean
         required: false
         default: true
-      deploy_cloud:
-        description: 'Deploy to cloud infrastructure'
-        type: boolean
-        required: false
-        default: true
   # New: auto-run on GitHub Release publish
   release:
     types: [published]
@@ -40,7 +35,6 @@ jobs:
       version_tag: ${{ steps.norm.outputs.version_tag }}
       ref: ${{ steps.norm.outputs.ref }}
       deploy_smoker_default: ${{ steps.norm.outputs.deploy_smoker_default }}
-      deploy_cloud_default: ${{ steps.norm.outputs.deploy_cloud_default }}
     steps:
       - id: norm
         shell: bash
@@ -51,7 +45,6 @@ jobs:
             VTAG="v${NUM}"
             REF="$VTAG"
             DEPLOY_SMOKER_DEFAULT=true
-            DEPLOY_CLOUD_DEFAULT=true
           else
             IN="${{ github.event.inputs.version }}"
             # trim whitespace and normalize leading V to v
@@ -62,13 +55,11 @@ jobs:
             # Use the tag ref when a tag exists; otherwise this will checkout the branch/commit if it matches
             REF="$VTAG"
             DEPLOY_SMOKER_DEFAULT=${{ github.event.inputs.deploy_smoker == 'true' && 'true' || 'false' }}
-            DEPLOY_CLOUD_DEFAULT=${{ github.event.inputs.deploy_cloud == 'true' && 'true' || 'false' }}
           fi
           echo "version_numeric=$NUM" >> "$GITHUB_OUTPUT"
           echo "version_tag=$VTAG" >> "$GITHUB_OUTPUT"
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "deploy_smoker_default=$DEPLOY_SMOKER_DEFAULT" >> "$GITHUB_OUTPUT"
-          echo "deploy_cloud_default=$DEPLOY_CLOUD_DEFAULT" >> "$GITHUB_OUTPUT"
 
   # Build smoker applications (no Docker)
   build-smoker:
@@ -76,15 +67,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       apps: '["smoker", "device-service", "electron-shell"]'
-      mode: 'build'
-      ref: ${{ needs.set-version.outputs.ref }}
-
-  # Build cloud applications (no Docker)
-  build-cloud:
-    needs: set-version
-    uses: ./.github/workflows/build.yml
-    with:
-      apps: '["backend", "frontend"]'
       mode: 'build'
       ref: ${{ needs.set-version.outputs.ref }}
 
@@ -100,30 +82,9 @@ jobs:
       platforms: 'linux/amd64,linux/arm/v7'
     secrets: inherit
 
-  # Build and publish cloud Docker images
-  publish-cloud:
-    needs: [set-version, build-cloud]
-    uses: ./.github/workflows/publish.yml
-    with:
-      apps: '["backend", "frontend"]'
-      version: ${{ needs.set-version.outputs.version_numeric }}
-      ref: ${{ needs.set-version.outputs.ref }}
-      mode: 'release'
-      platforms: 'linux/amd64,linux/arm/v7'
-    secrets: inherit
-
   # Deploy to smoker devices (optional; Watchtower will also update :latest)
   deploy-smoker:
     if: ${{ needs.set-version.outputs.deploy_smoker_default == 'true' }}
     needs: publish-smoker
     uses: ./.github/workflows/smoker-deploy.yml
-    secrets: inherit
-
-  # Deploy to cloud infrastructure (pinned to version tag)
-  deploy-cloud:
-    if: ${{ needs.set-version.outputs.deploy_cloud_default == 'true' }}
-    needs: publish-cloud
-    uses: ./.github/workflows/cloud-deploy.yml
-    with:
-      version: ${{ needs.set-version.outputs.version_tag }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Remove the prod-cloud rebuild/deploy path from `release.yml` so that promotion (not rebuild) becomes the sole producer of prod-cloud images. The smoker-device publish/deploy path stays intact.

## Closes

Closes #220 — release.yml: remove prod-cloud rebuild/deploy path

## Smoke

`smoke: SKIPPED — backend (3001) and frontend (3000) not running, services unreachable`

## Manual verification

- [ ] `release.yml` no longer rebuilds+deploys backend/frontend to prod-cloud
- [ ] Smoker-device publish/deploy path unchanged
- [ ] `actionlint` passes

---

Generated by `/team-pickup` at 2026-06-02T00:00:00+00:00