### PR TITLE
Closes #221: migrate-prod-data.sh: one-time guarded data migration

### DIFF
--- a/scripts/migrate-prod-data.sh
+++ b/scripts/migrate-prod-data.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# migrate-prod-data.sh — one-time guarded MongoDB data migration (deep module)
+#
+# Dumps from old prod via SSH and restores into new prod via SSH. The dump is
+# streamed directly into the restore (mongodump --archive | mongorestore
+# --archive) so no intermediate dump file ever touches disk on the operator's
+# machine.
+#
+# A run-once guard (sentinel file beside this script) prevents accidental
+# re-execution: once a migration has completed, subsequent invocations are
+# no-ops. This makes the script safe to wire into an automated cutover step
+# that might be retried.
+#
+# All remote work runs over `ssh root@<host>`, so SSH is the single system
+# boundary (mockable in tests by PATH-prepending an `ssh` stub).
+#
+# Usage:
+#   scripts/migrate-prod-data.sh <old-host> <new-host> [--db <dbname>]
+#
+# Parameters:
+#   old-host   SSH host of old prod (mongodump source), SSH'd as root@<host>.
+#   new-host   SSH host of new prod (mongorestore target), SSH'd as root@<host>.
+#   --db <n>   Database name (default: smart-smoker).
+#
+# Exit codes:
+#   0  migration completed (or already run — guard active)
+#   1  invalid arguments or migration failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD_FILE="${SCRIPT_DIR}/.migrate-prod-data.done"
+
+usage() {
+    echo "Usage: $(basename "$0") <old-host> <new-host> [--db <dbname>]" >&2
+}
+
+#-------------------------------------------------------------------------------
+# Argument parsing + validation
+#-------------------------------------------------------------------------------
+OLD_HOST="${1:-}"
+NEW_HOST="${2:-}"
+DB_NAME="smart-smoker"
+
+if [ -z "${OLD_HOST}" ] || [ -z "${NEW_HOST}" ]; then
+    echo "migrate-prod-data: missing required <old-host> and/or <new-host>" >&2
+    usage
+    exit 1
+fi
+
+shift 2 || true
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --db)
+            DB_NAME="${2:-}"
+            if [ -z "${DB_NAME}" ]; then
+                echo "migrate-prod-data: --db requires a value" >&2
+                usage
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            echo "migrate-prod-data: unknown argument '$1'" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+#-------------------------------------------------------------------------------
+# Run-once guard
+#-------------------------------------------------------------------------------
+if [ -f "${GUARD_FILE}" ]; then
+    echo "migrate-prod-data: already run — skipping"
+    exit 0
+fi
+
+#-------------------------------------------------------------------------------
+# Dump from old prod, restore into new prod (streamed).
+#
+# mongorestore --drop ensures the target collections are replaced rather than
+# merged, giving a clean cutover. The pipeline status is checked via
+# PIPESTATUS so a failure on either side fails the migration without creating
+# the guard (allowing a retry).
+#-------------------------------------------------------------------------------
+echo "migrate-prod-data: migrating db '${DB_NAME}' from ${OLD_HOST} -> ${NEW_HOST}"
+
+ssh "root@${OLD_HOST}" "mongodump --db '${DB_NAME}' --archive" \
+    | ssh "root@${NEW_HOST}" "mongorestore --archive --drop --db '${DB_NAME}'"
+
+# shellcheck disable=SC2206
+PIPE_STATUS=("${PIPESTATUS[@]}")
+DUMP_RC="${PIPE_STATUS[0]}"
+RESTORE_RC="${PIPE_STATUS[1]}"
+
+if [ "${DUMP_RC}" -ne 0 ] || [ "${RESTORE_RC}" -ne 0 ]; then
+    echo "migrate-prod-data: migration FAILED (mongodump=${DUMP_RC}, mongorestore=${RESTORE_RC})" >&2
+    echo "migrate-prod-data: guard NOT set — safe to retry" >&2
+    exit 1
+fi
+
+#-------------------------------------------------------------------------------
+# Success: set the run-once guard.
+#-------------------------------------------------------------------------------
+touch "${GUARD_FILE}"
+echo "migrate-prod-data: migration completed — guard set at ${GUARD_FILE}"
+exit 0

--- a/scripts/migrate-prod-data.test.sh
+++ b/scripts/migrate-prod-data.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Tests for scripts/migrate-prod-data.sh
+#
+# Run: bash scripts/migrate-prod-data.test.sh
+#
+# Strategy: migrate-prod-data.sh performs all remote work over `ssh root@<host>`.
+# We mock `ssh` by prepending a temp dir to PATH. The mock `ssh` appends each
+# invocation to a call log so tests can assert on ordering and content.
+#
+# The run-once guard is a sentinel file at ${SCRIPT_DIR}/.migrate-prod-data.done.
+# To keep tests hermetic we point the script at an isolated SCRIPT_DIR by copying
+# the script under test into a temp dir, so the guard file is created there and
+# never pollutes the real repo.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATE_SCRIPT="${SCRIPT_DIR}/migrate-prod-data.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_NAMES+=("$1")
+    echo "  FAIL: $1"
+    if [ -n "${2:-}" ]; then
+        echo "    $2"
+    fi
+}
+
+if [ ! -f "${MIGRATE_SCRIPT}" ]; then
+    echo "FATAL: ${MIGRATE_SCRIPT} not found"
+    exit 2
+fi
+
+# Create a mock bin dir containing an `ssh` stub that records its invocations to
+# ${SSH_CALL_LOG}. Each ssh invocation is logged as a single line: the full
+# argument vector. The stub also consumes stdin so a piped dump→restore does not
+# hang or fail on a broken pipe.
+make_mock_bin() {
+    local mock_dir
+    mock_dir="$(mktemp -d)"
+
+    cat > "${mock_dir}/ssh" <<'EOF'
+#!/usr/bin/env bash
+# Record the full invocation (one line per call).
+echo "ssh $*" >> "${SSH_CALL_LOG}"
+# Drain stdin so a piped mongodump | mongorestore does not break.
+cat >/dev/null 2>&1 || true
+exit 0
+EOF
+    chmod +x "${mock_dir}/ssh"
+
+    echo "${mock_dir}"
+}
+
+# Copy the script under test into an isolated dir so the guard sentinel is
+# written there (hermetic — never touches the real repo).
+make_isolated_script() {
+    local iso_dir
+    iso_dir="$(mktemp -d)"
+    cp "${MIGRATE_SCRIPT}" "${iso_dir}/migrate-prod-data.sh"
+    chmod +x "${iso_dir}/migrate-prod-data.sh"
+    echo "${iso_dir}"
+}
+
+#-------------------------------------------------------------------------------
+# Test 1: first run (guard absent) invokes ssh twice (mongodump source +
+#         mongorestore target) and creates the guard file afterward (AC 1).
+#-------------------------------------------------------------------------------
+test_first_run_success() {
+    echo "TEST: first run dumps then restores and creates guard"
+
+    local tmpdir call_log mock_dir iso_dir iso_script
+    tmpdir="$(mktemp -d)"
+    call_log="${tmpdir}/ssh-calls.log"
+    touch "${call_log}"
+    mock_dir="$(make_mock_bin)"
+    iso_dir="$(make_isolated_script)"
+    iso_script="${iso_dir}/migrate-prod-data.sh"
+    trap "rm -rf '${tmpdir}' '${mock_dir}' '${iso_dir}'" RETURN
+
+    export SSH_CALL_LOG="${call_log}"
+    PATH="${mock_dir}:${PATH}" \
+        bash "${iso_script}" oldprod newprod --db smart-smoker >/dev/null 2>&1
+    local exit_code=$?
+
+    if [ "${exit_code}" -ne 0 ]; then
+        fail "first run should exit 0" "got exit code ${exit_code}; calls:
+$(cat "${call_log}")"
+        return
+    fi
+
+    local calls
+    calls="$(cat "${call_log}")"
+
+    # Exactly two ssh calls: dump from old, restore into new.
+    local ssh_count
+    ssh_count="$(grep -c '^ssh ' "${call_log}")"
+    if [ "${ssh_count}" -ne 2 ]; then
+        fail "first run must issue exactly 2 ssh calls" "got ${ssh_count}; calls:
+${calls}"
+        return
+    fi
+
+    # Dump targets old host with mongodump; restore targets new host with mongorestore.
+    if ! grep -qF "root@oldprod" "${call_log}" || ! grep -qF "mongodump" "${call_log}"; then
+        fail "must mongodump from root@oldprod" "calls:
+${calls}"
+        return
+    fi
+    if ! grep -qF "root@newprod" "${call_log}" || ! grep -qF "mongorestore" "${call_log}"; then
+        fail "must mongorestore into root@newprod" "calls:
+${calls}"
+        return
+    fi
+
+    # Database name must appear in the remote commands.
+    if ! grep -qF "smart-smoker" "${call_log}"; then
+        fail "remote commands must reference the db name" "calls:
+${calls}"
+        return
+    fi
+
+    # Guard file must exist after a successful run.
+    if [ ! -f "${iso_dir}/.migrate-prod-data.done" ]; then
+        fail "guard file must be created after a successful migration" "calls:
+${calls}"
+        return
+    fi
+
+    pass "first run dumps then restores and creates guard"
+}
+
+#-------------------------------------------------------------------------------
+# Test 2: second run (guard present) exits 0 and issues NO ssh calls (AC 2).
+#-------------------------------------------------------------------------------
+test_guard_blocks_second_run() {
+    echo "TEST: existing guard blocks a second run"
+
+    local tmpdir call_log mock_dir iso_dir iso_script
+    tmpdir="$(mktemp -d)"
+    call_log="${tmpdir}/ssh-calls.log"
+    touch "${call_log}"
+    mock_dir="$(make_mock_bin)"
+    iso_dir="$(make_isolated_script)"
+    iso_script="${iso_dir}/migrate-prod-data.sh"
+    trap "rm -rf '${tmpdir}' '${mock_dir}' '${iso_dir}'" RETURN
+
+    # Pre-create the guard sentinel to simulate an already-completed migration.
+    touch "${iso_dir}/.migrate-prod-data.done"
+
+    export SSH_CALL_LOG="${call_log}"
+    PATH="${mock_dir}:${PATH}" \
+        bash "${iso_script}" oldprod newprod --db smart-smoker >/dev/null 2>&1
+    local exit_code=$?
+
+    if [ "${exit_code}" -ne 0 ]; then
+        fail "guarded second run must exit 0" "got exit code ${exit_code}"
+        return
+    fi
+
+    if [ -s "${call_log}" ]; then
+        fail "guarded second run must issue NO ssh calls" "got calls:
+$(cat "${call_log}")"
+        return
+    fi
+
+    pass "existing guard blocks a second run"
+}
+
+#-------------------------------------------------------------------------------
+# Run suite
+#-------------------------------------------------------------------------------
+echo "=========================================="
+echo "migrate-prod-data.sh tests"
+echo "=========================================="
+
+test_first_run_success
+test_guard_blocks_second_run
+
+echo ""
+echo "=========================================="
+echo "Ran: ${TESTS_RUN} | Failed: ${TESTS_FAILED}"
+echo "=========================================="
+
+if [ "${TESTS_FAILED}" -gt 0 ]; then
+    echo "Failed tests:"
+    for name in "${FAILED_NAMES[@]}"; do
+        echo "  - ${name}"
+    done
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Add `migrate-prod-data.sh`, a one-time guarded MongoDB data migration script that streams `mongodump` from old prod to `mongorestore` on new prod over SSH. A sentinel file prevents accidental re-runs.

## Closes

Closes #221 — migrate-prod-data.sh: one-time guarded data migration

## Smoke

`smoke: SKIPPED — backend/frontend/device services not running on localhost (connection refused on 3001/3000/3003)`

## Manual verification

- [ ] Script dumps from old prod and restores into new prod
- [ ] A run-once guard blocks a second migration
- [ ] Unit tests cover dump→restore invocation and the guard, mocking mongo tools

---

Generated by `/team-pickup` at 2026-06-02T00:00:00+00:00