### PR TITLE
chore(skills): tag AFK slices as team, add HITL label

### DIFF
--- a/.claude/skills/prd-to-issues/SKILL.md
+++ b/.claude/skills/prd-to-issues/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: prd-to-issues
-description: Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.
+description:
+  Break a PRD into independently-grabbable GitHub issues using tracer-bullet
+  vertical slices. Use when user wants to convert a PRD to issues, create
+  implementation tickets, or break down a PRD into work items.
 ---
 
 # PRD to Issues
 
-Break a PRD into independently-grabbable GitHub issues using vertical slices (tracer bullets).
+Break a PRD into independently-grabbable GitHub issues using vertical slices
+(tracer bullets).
 
 ## Process
 
@@ -13,17 +17,23 @@ Break a PRD into independently-grabbable GitHub issues using vertical slices (tr
 
 Ask the user for the PRD GitHub issue number (or URL).
 
-If the PRD is not already in your context window, fetch it with `gh issue view <number>` (with comments).
+If the PRD is not already in your context window, fetch it with
+`gh issue view <number>` (with comments).
 
 ### 2. Explore the codebase (optional)
 
-If you have not already explored the codebase, do so to understand the current state of the code.
+If you have not already explored the codebase, do so to understand the current
+state of the code.
 
 ### 3. Draft vertical slices
 
-Break the PRD into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+Break the PRD into **tracer bullet** issues. Each issue is a thin vertical slice
+that cuts through ALL integration layers end-to-end, NOT a horizontal slice of
+one layer.
 
-Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
+Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an
+architectural decision or a design review. AFK slices can be implemented and
+merged without human interaction. Prefer AFK over HITL where possible.
 
 <vertical-slice-rules>
 - Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
@@ -51,11 +61,28 @@ Iterate until the user approves the breakdown.
 
 ### 5. Create the GitHub issues
 
-For each approved slice, create a GitHub issue using `gh issue create`. Use the issue body template below.
+For each approved slice, create a GitHub issue using `gh issue create`. Use the
+issue body template below.
 
-Create issues in dependency order (blockers first) so you can reference real issue numbers in the "Blocked by" field.
+Create issues in dependency order (blockers first) so you can reference real
+issue numbers in the "Blocked by" field.
 
-For AFK slices, add the `ralph` label so they can be picked up by the autonomous Ralph loop: `gh issue create --label ralph ...`
+#### Labels
+
+First, bootstrap the labels (idempotent — safe to run every time):
+
+```bash
+gh label create "team" --description "Issue eligible for Level 7 agent team implementation" --color "1D76DB" --force
+gh label create "HITL" --description "Requires human in the loop; not eligible for autonomous agent implementation" --color "5319E7" --force
+```
+
+Then label each issue by type:
+
+- **AFK** slices → add the `team` label so they are eligible for autonomous
+  Level 7 agent-team pickup (`team-pickup` / `team-dispatch`):
+  `gh issue create --label team ...`
+- **HITL** slices → add the `HITL` label so human-required work is filterable
+  and excluded from autonomous pickup: `gh issue create --label HITL ...`
 
 <issue-template>
 ## Parent PRD
@@ -64,7 +91,9 @@ For AFK slices, add the `ralph` label so they can be picked up by the autonomous
 
 ## What to build
 
-A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation. Reference specific sections of the parent PRD rather than duplicating content.
+A concise description of this vertical slice. Describe the end-to-end behavior,
+not layer-by-layer implementation. Reference specific sections of the parent PRD
+rather than duplicating content.
 
 ## Acceptance criteria
 
@@ -74,14 +103,18 @@ A concise description of this vertical slice. Describe the end-to-end behavior, 
 
 ## Interface changes
 
-List the modules, services, or interfaces that will be created or modified for this slice. Be specific about what changes, but do not include file paths or code snippets.
+List the modules, services, or interfaces that will be created or modified for
+this slice. Be specific about what changes, but do not include file paths or
+code snippets.
 
 - Module/interface 1: what changes
 - Module/interface 2: what changes
 
 ## Behaviors to test
 
-Numbered list of observable behaviors to verify through public interfaces (not implementation details). Each behavior should map to one or more acceptance criteria.
+Numbered list of observable behaviors to verify through public interfaces (not
+implementation details). Each behavior should map to one or more acceptance
+criteria.
 
 1. Behavior description (maps to AC 1)
 2. Behavior description (maps to AC 2)

--- a/.claude/skills/write-a-prd/SKILL.md
+++ b/.claude/skills/write-a-prd/SKILL.md
@@ -1,23 +1,37 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description:
+  Create a PRD through user interview, codebase exploration, and module design,
+  then submit as a GitHub issue. Use when user wants to write a PRD, create a
+  product requirements document, or plan a new feature.
 ---
 
-This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
+This skill will be invoked when the user wants to create a PRD. You may skip
+steps if you don't consider them necessary.
 
-1. Ask the user for a long, detailed description of the problem they want to solve and any potential ideas for solutions.
+1. Ask the user for a long, detailed description of the problem they want to
+   solve and any potential ideas for solutions.
 
-2. Explore the repo to verify their assertions and understand the current state of the codebase.
+2. Explore the repo to verify their assertions and understand the current state
+   of the codebase.
 
-3. Interview the user relentlessly about every aspect of this plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+3. Interview the user relentlessly about every aspect of this plan until you
+   reach a shared understanding. Walk down each branch of the design tree,
+   resolving dependencies between decisions one-by-one.
 
-4. Sketch out the major modules you will need to build or modify to complete the implementation. Actively look for opportunities to extract deep modules that can be tested in isolation.
+4. Sketch out the major modules you will need to build or modify to complete the
+   implementation. Actively look for opportunities to extract deep modules that
+   can be tested in isolation.
 
-A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
+A deep module (as opposed to a shallow module) is one which encapsulates a lot
+of functionality in a simple, testable interface which rarely changes.
 
-Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
+Check with the user that these modules match their expectations. Check with the
+user which modules they want tests written for.
 
-5. Once you have a complete understanding of the problem and solution, use the template below to write the PRD. The PRD should be submitted as a GitHub issue.
+5. Once you have a complete understanding of the problem and solution, use the
+   template below to write the PRD. The PRD should be submitted as a GitHub
+   issue.
 
 <prd-template>
 
@@ -31,7 +45,8 @@ The solution to the problem, from the user's perspective.
 
 ## User Stories
 
-A LONG, numbered list of user stories. Each user story should be in the format of:
+A LONG, numbered list of user stories. Each user story should be in the format
+of:
 
 1. As an <actor>, I want a <feature>, so that <benefit>
 
@@ -39,7 +54,8 @@ A LONG, numbered list of user stories. Each user story should be in the format o
 1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
 </user-story-example>
 
-This list of user stories should be extremely extensive and cover all aspects of the feature.
+This list of user stories should be extremely extensive and cover all aspects of
+the feature.
 
 ## Implementation Decisions
 
@@ -53,13 +69,15 @@ A list of implementation decisions that were made. This can include:
 - API contracts
 - Specific interactions
 
-Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+Do NOT include specific file paths or code snippets. They may end up being
+outdated very quickly.
 
 ## Testing Decisions
 
 A list of testing decisions that were made. Include:
 
-- A description of what makes a good test (only test external behavior, not implementation details)
+- A description of what makes a good test (only test external behavior, not
+  implementation details)
 - Which modules will be tested
 - Prior art for the tests (i.e. similar types of tests in the codebase)
 
@@ -72,3 +90,17 @@ A description of the things that are out of scope for this PRD.
 Any further notes about the feature.
 
 </prd-template>
+
+## Label conventions
+
+This skill labels the PRD issue itself `prd` and does not create implementation
+tickets. When the PRD is later broken down by the `prd-to-issues` skill, each
+implementation slice is tagged by type:
+
+- `team` — AFK slice, eligible for autonomous Level 7 agent-team implementation.
+- `HITL` — slice that requires a human in the loop (e.g. architectural decision,
+  infra cutover, design review); excluded from autonomous pickup.
+
+Keep this split in mind while interviewing and sketching modules: prefer slices
+that can be fully automated (`team`) and call out the few that genuinely need a
+human (`HITL`).


### PR DESCRIPTION
## Summary

Updates the PRD pipeline skills so implementation tickets get tagged with the current convention:

- **prd-to-issues**: AFK slices now labeled `team` (Level 7 agent-team pickup) instead of the retired `ralph` loop. HITL slices now labeled `HITL`. Added an idempotent `gh label create ... --force` bootstrap so a missing label never breaks issue creation (mirrors `team-dispatch` pattern).
- **write-a-prd**: documents the `team`/`HITL` label convention so the PRD author plans slices with the split in mind. No behavior change to PRD creation.

## Notes

- Affects **future** `/prd-to-issues` runs only. Existing issues #217–#225 still carry old `ralph` tags — re-labeling those is a separate one-off.
- New `HITL` label color `5319E7` (purple); `team` already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)