### PR TITLE
fix(ci): scp -O in prod-deploy (OpenSSH 9 dir/. fix)

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Copy deployment files to prod host
         run: |
-          scp -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \
+          scp -O -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \
             cloud.docker-compose.yml \
             root@${{ vars.PROD_HOST }}:${{ vars.PROD_DEPLOY_DIR }}/cloud.docker-compose.yml
 
@@ -88,7 +88,7 @@ jobs:
             root@${{ vars.PROD_HOST }} \
             "mkdir -p ${{ vars.PROD_DEPLOY_DIR }}/infra/mongodb-init"
 
-          scp -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no -r \
+          scp -O -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no -r \
             infra/mongodb-init/. \
             root@${{ vars.PROD_HOST }}:${{ vars.PROD_DEPLOY_DIR }}/infra/mongodb-init/
 
@@ -103,7 +103,7 @@ jobs:
             "MONGO_APP_PASSWORD=${{ secrets.MONGO_APP_PASSWORD }}" \
             "ENCODED_MONGO_APP_PASSWORD=${ENCODED_PASSWORD}" \
             > /tmp/prod.env
-          scp -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \
+          scp -O -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \
             /tmp/prod.env \
             "root@${{ vars.PROD_HOST }}:${{ vars.PROD_DEPLOY_DIR }}/.env"
           ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \


### PR DESCRIPTION
## Why
Prod deploy failed at **Copy deployment files to prod host**:
```
scp: error: unexpected filename: .
```
on `scp -r infra/mongodb-init/. ...`. Modern OpenSSH (9.x) runs `scp` over the SFTP protocol by default, which rejects the `dir/.` "copy contents" idiom that the legacy SCP/RCP protocol accepted.

## What
Add `-O` (use the original SCP/RCP protocol) to the three `scp` calls in the deploy job. Restores `dir/.` behavior; no other change. `deploy-cloud.sh` does all remote work over `ssh` (no `scp`), so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)