### PR TITLE
fix(ci): tar-over-ssh for mongodb-init copy (scp dir/. fails)

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -88,9 +88,12 @@ jobs:
             root@${{ vars.PROD_HOST }} \
             "mkdir -p ${{ vars.PROD_DEPLOY_DIR }}/infra/mongodb-init"
 
-          scp -O -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no -r \
-            infra/mongodb-init/. \
-            root@${{ vars.PROD_HOST }}:${{ vars.PROD_DEPLOY_DIR }}/infra/mongodb-init/
+          # tar-over-ssh instead of `scp -r dir/.`: modern OpenSSH scp rejects
+          # the trailing-dot source ("unexpected filename: .") even with -O.
+          tar -C infra/mongodb-init -cf - . | \
+            ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \
+              root@${{ vars.PROD_HOST }} \
+              "tar -C ${{ vars.PROD_DEPLOY_DIR }}/infra/mongodb-init -xf -"
 
       - name: Write prod secrets to .env on prod host
         run: |


### PR DESCRIPTION
## Why
Even with `-O`, the deploy still failed at **Copy deployment files to prod host**:
```
scp: error: unexpected filename: .
```
This runner's OpenSSH `scp` rejects the `dir/.` "copy-contents" source path regardless of protocol, so `-O` (#234) was insufficient.

## What
Replace the one recursive `scp -r infra/mongodb-init/. …` with **tar piped over ssh**:
```
tar -C infra/mongodb-init -cf - . | ssh … "tar -C <dest>/infra/mongodb-init -xf -"
```
Portable, copies all contents (incl. dotfiles), no scp protocol quirks. The `mkdir -p` before it already creates the destination. Single-file `scp -O` calls (compose, .env) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)