### PR TITLE
fix(deploy): health-check localhost probes container ports not funnel HTTPS

### DIFF
--- a/scripts/deployment-health-check.sh
+++ b/scripts/deployment-health-check.sh
@@ -80,11 +80,18 @@ main() {
         TAILSCALE_FQDN="${TARGET_HOST}"
     fi
 
-    # Check Backend API (via Tailscale Serve HTTPS on port 8443)
-    check_service "Backend API" "https://${TAILSCALE_FQDN}:8443/api/health" || exit 1
-
-    # Check Frontend (via Tailscale Serve HTTPS on port 443)
-    check_service "Frontend" "https://${TAILSCALE_FQDN}" || exit 1
+    # Backend + Frontend reachability. On the deploy host itself (localhost),
+    # Tailscale Serve/Funnel binds the tailnet IP — not 127.0.0.1 — so probing
+    # https://localhost:8443 is refused. Check the container-published ports
+    # directly over HTTP instead. For remote targets, verify the public
+    # Tailscale HTTPS endpoints (Serve/Funnel on :443 / :8443).
+    if [ "${TARGET_HOST}" = "localhost" ] || [ "${TARGET_HOST}" = "127.0.0.1" ]; then
+        check_service "Backend API" "http://localhost:3001/api/health" || exit 1
+        check_service "Frontend" "http://localhost:80" || exit 1
+    else
+        check_service "Backend API" "https://${TAILSCALE_FQDN}:8443/api/health" || exit 1
+        check_service "Frontend" "https://${TAILSCALE_FQDN}" || exit 1
+    fi
 
     # Check Docker container health status (if running locally)
     if [ "${TARGET_HOST}" = "localhost" ] || [ "${TARGET_HOST}" = "127.0.0.1" ]; then


### PR DESCRIPTION
## Why
First funnel deploy (`prod-deploy.yml`) failed at deploy-cloud.sh's health-check → rollback, **despite all 3 containers healthy and the public funnel serving 200s**.

`deployment-health-check.sh` probed `https://${host}:8443/api/health` and `https://${host}` for every target. deploy-cloud.sh runs it **on the deploy host** with `target=localhost`. But Tailscale Serve/Funnel binds the **tailnet IP** (`100.x:443/8443`), not `127.0.0.1` — so `https://localhost:8443` is connection-refused. Verified the same on dev (`localhost:8443` refused there too); dev only passes because it deploys via the older path, not deploy-cloud.sh. deploy-cloud.sh is new (#227); prod-deploy is its first real user.

## What
For `localhost`/`127.0.0.1`, probe the container-published ports directly over HTTP:
- `http://localhost:3001/api/health`
- `http://localhost:80`

Remote targets keep the public Tailscale HTTPS checks. The container-health 3/3 gate is unchanged, and the workflow's **blocking smoke tests** still verify the public funnel URLs end-to-end from the runner.

Verified on the prod box: both local endpoints return 200, and the public funnel (`https://smokecloud-2.tail74646.ts.net` + `:8443/api/health`) serves 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)