### PR TITLE
Closes #238: Codify prod-deploy box/runner fixes into IaC + restore blocking smoke

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -95,6 +95,26 @@ jobs:
               root@${{ vars.PROD_HOST }} \
               "tar -C ${{ vars.PROD_DEPLOY_DIR }}/infra/mongodb-init -xf -"
 
+      - name: Copy deploy helper scripts to prod host
+        run: |
+          # These were previously scp'd by hand. The deploy/rollback/backup flow
+          # on the box depends on them, so ship them automatically every deploy.
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \
+            root@${{ vars.PROD_HOST }} \
+            "mkdir -p ${{ vars.PROD_DEPLOY_DIR }}/scripts"
+
+          scp -O -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \
+            scripts/deployment-backup.sh \
+            scripts/deployment-health-check.sh \
+            scripts/rollback.sh \
+            root@${{ vars.PROD_HOST }}:${{ vars.PROD_DEPLOY_DIR }}/scripts/
+
+          ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no \
+            root@${{ vars.PROD_HOST }} \
+            "chmod +x ${{ vars.PROD_DEPLOY_DIR }}/scripts/deployment-backup.sh \
+                      ${{ vars.PROD_DEPLOY_DIR }}/scripts/deployment-health-check.sh \
+                      ${{ vars.PROD_DEPLOY_DIR }}/scripts/rollback.sh"
+
       - name: Write prod secrets to .env on prod host
         run: |
           ENCODED_PASSWORD=$(printf '%s' "${{ secrets.MONGO_APP_PASSWORD }}" | jq -sRr @uri)
@@ -125,41 +145,6 @@ jobs:
         env:
           DEPLOY_WAIT_SECONDS: '120'
           HEALTH_RETRIES: '5'
-
-      - name: Setup Node for smoke tests
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      # Smoke is advisory for now: the self-hosted runner has no passwordless
-      # sudo, so `playwright install --with-deps` cannot install browser system
-      # libs. This mirrors dev-deploy's bake-window posture. Restore blocking by
-      # removing continue-on-error once smoke runs on a runner with Playwright
-      # (e.g. a dedicated ubuntu-latest smoke job against the public funnel URLs).
-      - name: Install smoke dependencies
-        id: smoke_install
-        continue-on-error: true
-        run: |
-          npm --prefix scripts/smoke ci
-          npm --prefix scripts/smoke run smoke:install
-
-      - name: Run post-deploy smoke tests (advisory)
-        id: smoke
-        continue-on-error: true
-        run: |
-          npm --prefix scripts/smoke run smoke -- \
-            --frontend "https://${{ vars.PROD_FQDN }}" \
-            --backend "https://${{ vars.PROD_FQDN }}:8443" \
-            --artifacts /tmp/prod-smoke-artifacts
-
-      - name: Upload smoke artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: prod-deploy-smoke-artifacts
-          path: /tmp/prod-smoke-artifacts/
-          if-no-files-found: ignore
-          retention-days: 30
 
       - name: Revoke SSH key
         if: always()
@@ -210,3 +195,45 @@ jobs:
           curl -fsS -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD" || echo "Discord notification failed (non-fatal)"
+
+  # Blocking smoke gate. Runs on a GitHub-hosted ubuntu-latest runner so
+  # Playwright can install its browser system libs (the self-hosted proxmox
+  # runner has no passwordless sudo, which is why #237 had to downgrade smoke to
+  # advisory). It hits the PUBLIC funnel URLs, so it needs no Tailscale. A smoke
+  # failure fails this job and therefore the whole prod-deploy run — the gate is
+  # real again. No Discord step here: the deploy job already notifies, and a
+  # failed CI run is sufficient signal.
+  smoke:
+    name: Post-deploy smoke (blocking)
+    needs: [promote, deploy]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node for smoke tests
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install smoke dependencies
+        run: |
+          npm --prefix scripts/smoke ci
+          npm --prefix scripts/smoke run smoke:install
+
+      - name: Run post-deploy smoke tests against public funnel
+        run: |
+          npm --prefix scripts/smoke run smoke -- \
+            --frontend "https://${{ vars.PROD_FQDN }}" \
+            --backend "https://${{ vars.PROD_FQDN }}:8443" \
+            --artifacts /tmp/prod-smoke-artifacts
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-deploy-smoke-artifacts
+          path: /tmp/prod-smoke-artifacts/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/docs/Infrastructure/features/configuration/ansible.md
+++ b/docs/Infrastructure/features/configuration/ansible.md
@@ -19,7 +19,8 @@ The infrastructure is managed through 7 specialized Ansible roles:
    - Base package installation
 
 2. **docker** - Container runtime
-   - Docker Engine installation
+   - Docker Engine + **crun** OCI runtime installation (crun required in unprivileged LXC; runc fails on `net.ipv4.ip_unprivileged_port_start`)
+   - `daemon.json`: `default-runtime: crun`, non-overlapping `default-address-pools` base (`172.20.0.0/16`)
    - Docker Compose plugin
    - User permissions and daemon configuration
 
@@ -40,7 +41,12 @@ The infrastructure is managed through 7 specialized Ansible roles:
    - MongoDB data directories
    - User/group setup
 
-7. **virtual-device** - Virtual smoker device
+7. **dns-guard** - Persistent DNS resilience
+   - Systemd timer+oneshot that probes `registry-1.docker.io` and rewrites `/etc/resolv.conf` from a template (nameservers: 1.1.1.1, 8.8.8.8, 8.8.4.4)
+   - Required on cloud boxes: the isolated bridge resets resolv.conf to unreachable `10.0.0.x` on reboot, breaking apt/`docker pull`
+   - Applied to both dev-cloud and prod-cloud (must run **before** the `docker` role)
+
+8. **virtual-device** - Virtual smoker device
    - Device directories
    - Python tools for simulation
    - Hardware mocking tools

--- a/docs/Infrastructure/features/infrastructure/terraform.md
+++ b/docs/Infrastructure/features/infrastructure/terraform.md
@@ -158,7 +158,7 @@ terraform apply tfplan
 - **Purpose**: Production environment for cloud services
 - **Resources**: 4 CPU cores, 8GB RAM, 40GB disk
 - **Network**: vmbr0 (10.20.0.30/24)
-- **Features**: Docker, Docker Compose, Git, automated backups
+- **Features**: Docker (crun runtime), Docker Compose, Git, automated backups, keyctl enabled
 
 ### Networking
 
@@ -178,6 +178,7 @@ All infrastructure is organized in the `smart-smoker` resource pool for easier m
 - **Nesting**: Enabled on all containers for Docker-in-Docker support
 - **Unprivileged**: All containers run as unprivileged for security
 - **Auto-start**: Containers start automatically on host boot
+- **keyctl**: Optional per-container kernel keyring access (`keyctl = true` in tfvars). Required on prod CT (104/108) for workloads that use the kernel keyring in unprivileged LXC. Previously hand-edited drift; now modelled in the `lxc-container` module `features` object.
 
 ### Networking Configuration
 

--- a/infra/proxmox/ansible/playbooks/setup-prod-cloud.yml
+++ b/infra/proxmox/ansible/playbooks/setup-prod-cloud.yml
@@ -9,6 +9,11 @@
 
   roles:
     - common
+    # dns-guard must run before docker so that resolv.conf points at a reachable
+    # nameserver (1.1.1.1) when docker pulls images. Without it the isolated
+    # bridge resets resolv.conf to the unreachable 10.0.0.x gateway and
+    # apt/docker pull fail after a reboot.
+    - dns-guard
     - docker
     - nodejs
     - cloud-app

--- a/infra/proxmox/ansible/roles/docker/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/docker/tasks/main.yml
@@ -71,6 +71,16 @@
     - docker-ce-cli
   when: docker_version | length > 0
 
+- name: Install crun OCI runtime
+  ansible.builtin.apt:
+    name: crun
+    state: present
+    update_cache: true
+  # runc fails with "net.ipv4.ip_unprivileged_port_start: permission denied"
+  # inside an unprivileged LXC. crun honours the sysctl that the unprivileged
+  # container already has set, so containers binding low ports actually start.
+  notify: Restart docker
+
 - name: Install Docker Compose plugin (latest)
   ansible.builtin.apt:
     name: docker-compose-plugin
@@ -110,9 +120,15 @@
         "live-restore": true,
         "userland-proxy": false,
         "storage-driver": "overlay2",
+        "default-runtime": "crun",
+        "runtimes": {
+          "crun": {
+            "path": "/usr/bin/crun"
+          }
+        },
         "default-address-pools": [
           {
-            "base": "172.17.0.0/16",
+            "base": "172.20.0.0/16",
             "size": 24
           }
         ]

--- a/infra/proxmox/iac-hardening.test.sh
+++ b/infra/proxmox/iac-hardening.test.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# Regression tests for the prod-deploy IaC hardening slice (issue #238).
+#
+# Running the first gated production deploy required a chain of manual fixes
+# applied directly to the prod box and its daemon config. This suite locks those
+# fixes into infrastructure-as-code so a rebuild/reprovision reproduces a working
+# box and the prod smoke gate is real (blocking) again.
+#
+# The assertions are intentionally config-level: each fix corresponds to a
+# specific line/setting in an Ansible role, a Terraform module, or a workflow.
+# They guard against silent regression of the exact settings that broke the
+# deploy.
+#
+# Run: bash infra/proxmox/iac-hardening.test.sh
+# Or:  ./infra/proxmox/iac-hardening.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DOCKER_TASKS="${SCRIPT_DIR}/ansible/roles/docker/tasks/main.yml"
+PROD_PLAYBOOK="${SCRIPT_DIR}/ansible/playbooks/setup-prod-cloud.yml"
+LXC_MODULE_MAIN="${SCRIPT_DIR}/terraform/modules/lxc-container/main.tf"
+LXC_MODULE_VARS="${SCRIPT_DIR}/terraform/modules/lxc-container/variables.tf"
+PROD_ENV_VARS="${SCRIPT_DIR}/terraform/environments/prod-cloud/variables.tf"
+PROD_DEPLOY_WF="${REPO_ROOT}/.github/workflows/prod-deploy.yml"
+
+# Test counters
+TESTS_RUN=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_NAMES+=("$1")
+    echo "  FAIL: $1"
+    if [ -n "${2:-}" ]; then
+        echo "    $2"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# AC 1: the docker role installs crun and sets crun as the default runtime.
+# runc fails on net.ipv4.ip_unprivileged_port_start in an unprivileged LXC, so
+# the box must run containers under crun or no app container starts.
+#-------------------------------------------------------------------------------
+test_docker_role_installs_crun() {
+    echo "TEST: docker role installs crun and sets default-runtime: crun"
+
+    if [ ! -f "${DOCKER_TASKS}" ]; then
+        fail "docker tasks file exists" "missing: ${DOCKER_TASKS}"
+        return
+    fi
+
+    if ! grep -qE '(^|[^[:alnum:]])crun([^[:alnum:]]|$)' "${DOCKER_TASKS}"; then
+        fail "docker role must install the crun package" \
+             "no 'crun' package reference found in ${DOCKER_TASKS}"
+        return
+    fi
+
+    if ! grep -q '"default-runtime": *"crun"' "${DOCKER_TASKS}"; then
+        fail "daemon.json must set \"default-runtime\": \"crun\"" \
+             "runc default would fail on ip_unprivileged_port_start in unprivileged LXC"
+        return
+    fi
+
+    pass "docker role installs crun and sets default-runtime: crun"
+}
+
+#-------------------------------------------------------------------------------
+# AC 2: the daemon.json default-address-pools must NOT use the docker0-
+# overlapping 172.17.0.0/16 base. With it, Docker reports "all predefined
+# address pools have been fully subnetted" and refuses to create the compose
+# network. A pool must be present (so user-defined networks get a deterministic
+# range) but it must not collide with docker0.
+#-------------------------------------------------------------------------------
+test_docker_address_pool_not_overlapping() {
+    echo "TEST: daemon.json address pool does not overlap docker0 (172.17.0.0/16)"
+
+    if [ ! -f "${DOCKER_TASKS}" ]; then
+        fail "docker tasks file exists" "missing: ${DOCKER_TASKS}"
+        return
+    fi
+
+    if grep -q '"base": *"172\.17\.0\.0/16"' "${DOCKER_TASKS}"; then
+        fail "address pool base must not be 172.17.0.0/16 (overlaps docker0)" \
+             "this triggers 'all predefined address pools have been fully subnetted'"
+        return
+    fi
+
+    if ! grep -q '"default-address-pools"' "${DOCKER_TASKS}"; then
+        fail "daemon.json must still define default-address-pools" \
+             "a non-overlapping pool keeps compose network ranges deterministic"
+        return
+    fi
+
+    pass "daemon.json address pool does not overlap docker0"
+}
+
+#-------------------------------------------------------------------------------
+# AC 3: prod-cloud must get persistent working DNS that survives reboot. The
+# dns-guard role ships a systemd timer + known-good resolv.conf (1.1.1.1) that
+# remediates the resolv.conf reset to the unreachable 10.0.0.1/10.0.0.2 on the
+# isolated bridge. The prod-cloud playbook must apply that role.
+#-------------------------------------------------------------------------------
+test_prod_playbook_applies_dns_guard() {
+    echo "TEST: setup-prod-cloud playbook applies the dns-guard role"
+
+    if [ ! -f "${PROD_PLAYBOOK}" ]; then
+        fail "prod-cloud playbook exists" "missing: ${PROD_PLAYBOOK}"
+        return
+    fi
+
+    # Match the role only within the roles: list (a leading '- ' list entry),
+    # not an incidental mention in a comment or debug message.
+    if ! grep -qE '^[[:space:]]*-[[:space:]]+dns-guard[[:space:]]*$' "${PROD_PLAYBOOK}"; then
+        fail "setup-prod-cloud.yml must list the dns-guard role" \
+             "without it resolv.conf resets to unreachable 10.0.0.x and apt/docker pull break"
+        return
+    fi
+
+    pass "setup-prod-cloud playbook applies the dns-guard role"
+}
+
+#-------------------------------------------------------------------------------
+# AC 4: Terraform must model the container keyctl feature so it is no longer
+# hand-edited drift on the prod CTs. The lxc-container module's features object
+# must expose keyctl, and the resource must wire it into the features block.
+#-------------------------------------------------------------------------------
+test_lxc_module_models_keyctl() {
+    echo "TEST: lxc-container module models the keyctl feature"
+
+    if [ ! -f "${LXC_MODULE_VARS}" ] || [ ! -f "${LXC_MODULE_MAIN}" ]; then
+        fail "lxc-container module files exist" \
+             "missing ${LXC_MODULE_VARS} or ${LXC_MODULE_MAIN}"
+        return
+    fi
+
+    # The features object variable must declare a keyctl attribute.
+    if ! grep -qE 'keyctl[[:space:]]*=[[:space:]]*optional\(bool' "${LXC_MODULE_VARS}"; then
+        fail "features variable must declare an optional keyctl bool" \
+             "no 'keyctl = optional(bool ...' in ${LXC_MODULE_VARS}"
+        return
+    fi
+
+    # The resource must wire keyctl from the features value into the features
+    # block so a tfvars setting actually reaches Proxmox.
+    if ! grep -qE 'keyctl[[:space:]]*=[[:space:]]*try\(features\.value\.keyctl' "${LXC_MODULE_MAIN}"; then
+        fail "container resource must wire features.value.keyctl into the features block" \
+             "no 'keyctl = try(features.value.keyctl ...' in ${LXC_MODULE_MAIN}"
+        return
+    fi
+
+    pass "lxc-container module models the keyctl feature"
+}
+
+#-------------------------------------------------------------------------------
+# AC 4 (cont.): the prod-cloud environment passes its features object straight
+# through to the module (features = var.features). Its own features variable
+# type must therefore also accept keyctl, or a tfvars that sets keyctl on the
+# prod CT (104) fails terraform validate and the keyctl wiring never reaches the
+# module.
+#-------------------------------------------------------------------------------
+test_prod_env_features_accepts_keyctl() {
+    echo "TEST: prod-cloud env features variable accepts keyctl"
+
+    if [ ! -f "${PROD_ENV_VARS}" ]; then
+        fail "prod-cloud env variables file exists" "missing: ${PROD_ENV_VARS}"
+        return
+    fi
+
+    if ! grep -qE 'keyctl[[:space:]]*=[[:space:]]*optional\(bool' "${PROD_ENV_VARS}"; then
+        fail "prod-cloud features variable must declare an optional keyctl bool" \
+             "no 'keyctl = optional(bool ...' in ${PROD_ENV_VARS}"
+        return
+    fi
+
+    pass "prod-cloud env features variable accepts keyctl"
+}
+
+#-------------------------------------------------------------------------------
+# AC 6: prod smoke must be blocking again, running from a dedicated
+# ubuntu-latest job against the public funnel URLs (no Tailscale needed). The
+# advisory continue-on-error from #237 must be gone from the smoke steps, and a
+# distinct ubuntu-latest smoke job that runs after deploy must exist.
+#-------------------------------------------------------------------------------
+test_prod_deploy_smoke_is_blocking() {
+    echo "TEST: prod-deploy smoke runs as a blocking ubuntu-latest job"
+
+    if [ ! -f "${PROD_DEPLOY_WF}" ]; then
+        fail "prod-deploy workflow exists" "missing: ${PROD_DEPLOY_WF}"
+        return
+    fi
+
+    # A dedicated smoke job keyed under jobs: must exist.
+    if ! grep -qE '^[[:space:]]{2}smoke:' "${PROD_DEPLOY_WF}"; then
+        fail "prod-deploy.yml must define a dedicated 'smoke' job" \
+             "smoke must run from its own job, not inside the self-hosted deploy job"
+        return
+    fi
+
+    # That smoke job must run on ubuntu-latest (Playwright-capable, public funnel).
+    if ! grep -qE 'runs-on:[[:space:]]*ubuntu-latest' "${PROD_DEPLOY_WF}"; then
+        fail "the smoke job must run on ubuntu-latest" \
+             "self-hosted runner cannot install Playwright system deps"
+        return
+    fi
+
+    # The advisory escape hatch must be gone — smoke failure must fail the run.
+    if grep -q 'continue-on-error' "${PROD_DEPLOY_WF}"; then
+        fail "prod-deploy.yml must not contain continue-on-error (smoke is blocking)" \
+             "the #237 advisory downgrade must be reverted"
+        return
+    fi
+
+    # The smoke job must depend on the deploy job (run after a successful deploy).
+    if ! grep -qE 'needs:.*deploy' "${PROD_DEPLOY_WF}"; then
+        fail "the smoke job must declare 'needs: ... deploy'" \
+             "smoke runs only after the deploy job succeeds"
+        return
+    fi
+
+    pass "prod-deploy smoke runs as a blocking ubuntu-latest job"
+}
+
+#-------------------------------------------------------------------------------
+# AC 5: the deploy must copy the helper scripts (deployment-backup.sh,
+# deployment-health-check.sh, rollback.sh) to the box itself — they were scp'd
+# by hand. The workflow must reference all three in a copy step.
+#-------------------------------------------------------------------------------
+test_prod_deploy_copies_helper_scripts() {
+    echo "TEST: prod-deploy copies the deploy helper scripts to the box"
+
+    if [ ! -f "${PROD_DEPLOY_WF}" ]; then
+        fail "prod-deploy workflow exists" "missing: ${PROD_DEPLOY_WF}"
+        return
+    fi
+
+    local missing=()
+    for s in deployment-backup.sh deployment-health-check.sh rollback.sh; do
+        if ! grep -q "${s}" "${PROD_DEPLOY_WF}"; then
+            missing+=("${s}")
+        fi
+    done
+
+    if [ "${#missing[@]}" -gt 0 ]; then
+        fail "prod-deploy.yml must copy all deploy helper scripts" \
+             "missing references: ${missing[*]}"
+        return
+    fi
+
+    pass "prod-deploy copies the deploy helper scripts to the box"
+}
+
+#-------------------------------------------------------------------------------
+# Run the suite
+#-------------------------------------------------------------------------------
+echo "=========================================="
+echo "prod-deploy IaC hardening regression tests"
+echo "=========================================="
+
+test_docker_role_installs_crun
+test_docker_address_pool_not_overlapping
+test_prod_playbook_applies_dns_guard
+test_lxc_module_models_keyctl
+test_prod_env_features_accepts_keyctl
+test_prod_deploy_smoke_is_blocking
+test_prod_deploy_copies_helper_scripts
+
+echo ""
+echo "=========================================="
+echo "Ran: ${TESTS_RUN} | Failed: ${TESTS_FAILED}"
+echo "=========================================="
+
+if [ "${TESTS_FAILED}" -gt 0 ]; then
+    echo "Failed tests:"
+    for name in "${FAILED_NAMES[@]}"; do
+        echo "  - ${name}"
+    done
+    exit 1
+fi
+
+exit 0

--- a/infra/proxmox/terraform/environments/prod-cloud/variables.tf
+++ b/infra/proxmox/terraform/environments/prod-cloud/variables.tf
@@ -101,7 +101,10 @@ variable "features" {
   type = object({
     nesting = optional(bool)
     fuse    = optional(bool)
-    mount   = optional(list(string))
+    # keyctl is required on the prod CT (104); modeled here so it is no longer
+    # hand-edited drift. Passed straight through to the lxc-container module.
+    keyctl = optional(bool)
+    mount  = optional(list(string))
   })
   default = null
 }

--- a/infra/proxmox/terraform/modules/lxc-container/main.tf
+++ b/infra/proxmox/terraform/modules/lxc-container/main.tf
@@ -35,6 +35,7 @@ resource "proxmox_virtual_environment_container" "this" {
     content {
       nesting = try(features.value.nesting, null)
       fuse    = try(features.value.fuse, null)
+      keyctl  = try(features.value.keyctl, null)
       mount   = try(features.value.mount, null)
     }
   }

--- a/infra/proxmox/terraform/modules/lxc-container/variables.tf
+++ b/infra/proxmox/terraform/modules/lxc-container/variables.tf
@@ -144,7 +144,10 @@ variable "features" {
   type = object({
     nesting = optional(bool)
     fuse    = optional(bool)
-    mount   = optional(list(string))
+    # keyctl lets containers use the kernel keyring (required by some workloads
+    # in unprivileged LXC). Previously hand-set on the prod CTs, causing drift.
+    keyctl = optional(bool)
+    mount  = optional(list(string))
   })
   default = null
 }


### PR DESCRIPTION
## Summary

Codifies the chain of manual fixes applied to the prod box (`smokecloud-2` / CT 104) during the first gated production deploy into infrastructure-as-code, so a rebuild/reprovision reproduces a working box automatically.

## Closes

Closes #238 — Codify prod-deploy box/runner fixes into IaC + restore blocking smoke

## Smoke

`smoke: SKIPPED — no local server (backend :3001 and frontend :3000 unreachable)`

## Manual verification

- [ ] Ansible `docker` role installs **crun** and sets `daemon.json` `default-runtime: crun` (runc fails on `net.ipv4.ip_unprivileged_port_start` in unprivileged LXC)
- [ ] Ansible `docker` role does **not** emit the broken `default-address-pools` base `172.17.0.0/16`; uses `172.20.0.0/16` instead
- [ ] Cloud boxes get **persistent working DNS** (e.g. `1.1.1.1`) that survives reboot — `dns-guard` role added to `setup-prod-cloud.yml`
- [ ] Terraform models the container `keyctl=1` feature (`lxc.cgroup2.devices.allow` / `lxc.mount.entry` raw config lines are out of scope — bpg provider does not support raw lxc config)
- [ ] `prod-deploy.yml` copies the deploy helper scripts (`deployment-backup.sh`, `deployment-health-check.sh`, `rollback.sh`) to the box automatically
- [ ] Prod smoke is **blocking again**: dedicated `ubuntu-latest` smoke job (`needs: [promote, deploy]`), `continue-on-error` removed
- [ ] Regression suite `infra/proxmox/iac-hardening.test.sh` passes (7/7 tests)

---

Generated by `/team-pickup` at 2026-06-07T00:00:00Z