### PR TITLE
fix(infra): runner toolchain — terraform + ansible PATH

### DIFF
--- a/.github/workflows/ansible-prod-cloud.yml
+++ b/.github/workflows/ansible-prod-cloud.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Install Ansible
         run: |
           pip install --user ansible --quiet
-          ansible-galaxy collection install community.general ansible.posix --force --quiet
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install community.general ansible.posix --force --quiet
 
       - name: Run ansible-playbook setup-prod-cloud.yml
         if: ${{ inputs.run_ansible }}

--- a/.github/workflows/infra-provision-vm.yml
+++ b/.github/workflows/infra-provision-vm.yml
@@ -25,7 +25,7 @@ permissions:
 
 concurrency:
   group: ansible-provision-dev
-  cancel-in-progress: false  # Don't cancel in-progress provisioning; queues behind ansible-provision.yml
+  cancel-in-progress: false # Don't cancel in-progress provisioning; queues behind ansible-provision.yml
 
 jobs:
   # Step 1: Terraform apply to create/update the VM
@@ -38,6 +38,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Ensure Terraform installed
+        run: |
+          if ! command -v terraform &>/dev/null; then
+            TFVER=$(curl -sL https://checkpoint-api.hashicorp.com/v1/check/terraform | python3 -c "import sys,json; print(json.load(sys.stdin)['current_version'])")
+            curl -sLo /tmp/tf.zip "https://releases.hashicorp.com/terraform/${TFVER}/terraform_${TFVER}_linux_amd64.zip"
+            sudo unzip -o /tmp/tf.zip -d /usr/local/bin/ && rm /tmp/tf.zip
+          fi
+          terraform version
 
       - name: Terraform Init
         working-directory: infra/proxmox/terraform
@@ -134,7 +143,10 @@ jobs:
       - name: Install Ansible dependencies
         run: |
           pip install --user ansible
-          ansible-galaxy collection install community.general ansible.posix --force
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install community.general ansible.posix --force
 
       - name: Run Ansible playbook
         working-directory: infra/proxmox/ansible

--- a/infra/proxmox/ansible/roles/github-runner/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/github-runner/tasks/main.yml
@@ -1,4 +1,42 @@
 ---
+# =============================================================================
+# Toolchain — tools workflows call directly on the runner
+# =============================================================================
+
+- name: Install pip3
+  ansible.builtin.apt:
+    name: python3-pip
+    state: present
+    update_cache: false
+
+- name: Install Ansible via pip (system-wide so PATH needs no adjustment)
+  ansible.builtin.pip:
+    name: ansible
+    state: present
+    executable: pip3
+
+- name: Install Ansible collections
+  ansible.builtin.command:
+    cmd: ansible-galaxy collection install community.general ansible.posix --force
+  changed_when: true
+  become: false
+
+- name: Get latest Terraform version
+  ansible.builtin.uri:
+    url: https://checkpoint-api.hashicorp.com/v1/check/terraform
+    return_content: true
+  register: tf_latest
+
+- name: Install Terraform binary
+  ansible.builtin.unarchive:
+    src: "https://releases.hashicorp.com/terraform/{{ tf_latest.json.current_version }}/terraform_{{ tf_latest.json.current_version }}_linux_amd64.zip"
+    dest: /usr/local/bin/
+    remote_src: true
+    creates: /usr/local/bin/terraform
+    mode: "0755"
+
+# =============================================================================
+
 - name: Set runner install directory
   ansible.builtin.set_fact:
     github_runner_install_dir: "{{ github_runner_install_dir | default(github_runner_home + '/actions-runner') }}"


### PR DESCRIPTION
## Summary

- `ansible-prod-cloud.yml` and `infra-provision-vm.yml` both failed because `pip install --user` puts binaries in `~/.local/bin` which is not in PATH for non-interactive shells. Fixed by splitting the install step and emitting `$HOME/.local/bin` via `$GITHUB_PATH` (the correct GitHub Actions pattern).
- `infra-provision-vm.yml` failed with `terraform: command not found` — terraform was never installed on the proxmox runner. Added an `Ensure Terraform installed` guard step that bootstraps the binary if absent.
- `github-runner` Ansible role: added pre-install of `terraform` binary and `ansible` (system-wide via pip3) so the next runner re-provision makes both permanently available without workflow workarounds.

## Test plan

- [ ] Merge → CI (Ansible Lint) green
- [ ] Trigger `ansible-prod-cloud.yml` (verify-only) — all steps pass
- [ ] Trigger `infra-provision-vm.yml` manually — terraform step no longer errors