### PR TITLE
fix(ci): drop --quiet from ansible-galaxy collection install

### DIFF
--- a/.github/workflows/ansible-prod-cloud.yml
+++ b/.github/workflows/ansible-prod-cloud.yml
@@ -47,7 +47,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install Ansible collections
-        run: ansible-galaxy collection install community.general ansible.posix --force --quiet
+        run: ansible-galaxy collection install community.general ansible.posix --force
 
       - name: Run ansible-playbook setup-prod-cloud.yml
         if: ${{ inputs.run_ansible }}


### PR DESCRIPTION
## Summary

`--quiet` is not a valid flag for `ansible-galaxy collection install` — causes exit code 2 (prints usage/help) which aborted the `ansible-prod-cloud.yml` verification run and skipped all 6 AC checks.

One-line fix: remove the invalid flag.

## Test plan

- [ ] Merge → trigger `ansible-prod-cloud.yml` (verify-only) → all verification steps run