### PR TITLE
fix(ci): 4d mongo auth via container env vars

### DIFF
--- a/.github/workflows/ansible-prod-cloud.yml
+++ b/.github/workflows/ansible-prod-cloud.yml
@@ -92,7 +92,7 @@ jobs:
           fi
           echo "PASS: MongoDB localhost-only or not yet started ($LOCAL)"
 
-      - name: 4d — MongoDB seeded users (start mongo, check, stop)
+      - name: 4d — MongoDB seeded users (start mongo if needed, check via container env)
         id: verify_mongo_users
         continue-on-error: true
         run: |
@@ -101,18 +101,25 @@ jobs:
           ssh -o BatchMode=yes root@smokecloud-2 "
             set -e
             cd $APP_DIR
-            docker compose -f $COMPOSE up -d mongo
-            echo 'Waiting for mongo init...'
-            sleep 15
-            USERS=\$(docker exec smart-smoker-mongo mongosh admin \
-              -u root -p \"\$MONGO_ROOT_PASSWORD\" --quiet \
-              --eval 'db.getUsers().users.map(u=>u.user).join(\",\")' 2>/dev/null || echo ERROR)
+            RUNNING=\$(docker inspect -f '{{.State.Running}}' smart-smoker-mongo 2>/dev/null || echo false)
+            if [ \"\$RUNNING\" != 'true' ]; then
+              docker compose -f $COMPOSE up -d mongo
+              echo 'Started mongo, waiting for init...'
+              sleep 20
+              STARTED_HERE=1
+            fi
+            # Use the container's own env vars for credentials — host shell has no MONGO_ROOT_PASSWORD
+            USERS=\$(docker exec smart-smoker-mongo sh -c \
+              'mongosh admin -u \"\$MONGO_INITDB_ROOT_USERNAME\" -p \"\$MONGO_INITDB_ROOT_PASSWORD\" --quiet \
+               --eval \"db.getUsers().users.map(u=>u.user).join(\\\",\\\")\"' 2>/dev/null || echo ERROR)
             echo \"Users found: \$USERS\"
-            docker compose -f $COMPOSE stop mongo
+            if [ \"\${STARTED_HERE:-0}\" = '1' ]; then
+              docker compose -f $COMPOSE stop mongo
+            fi
             if echo \"\$USERS\" | grep -q smartsmoker; then
               echo 'PASS: smartsmoker user present'
             else
-              echo 'FAIL: smartsmoker user missing'
+              echo 'FAIL: smartsmoker user missing or mongosh ERROR'
               exit 1
             fi
           "


### PR DESCRIPTION
## Summary

- **4d fix**: `$MONGO_ROOT_PASSWORD` is not in the SSH shell environment — it's only inside the docker container (set via compose `environment:` / `.env`). Switch to `docker exec sh -c` using the container's own `MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD` vars.
- Don't start/stop mongo if it's already running — avoids disturbing a live prod stack.

## 4e (backup timer inactive) — separate issue

The `backup-mongodb.timer` is inactive because the ansible `backups` role has not been applied to `smokecloud-2`. This requires triggering the workflow with `run_ansible=true`. That's a prod-config change — needs your explicit trigger via the Actions UI or:
```bash
gh workflow run ansible-prod-cloud.yml --ref master --field run_ansible=true
```

## Test plan

- [ ] Merge → trigger `ansible-prod-cloud.yml` verify-only → 4d passes
- [ ] Separately trigger with `run_ansible=true` to fix 4e (backup timer)