### PR TITLE
fix(ci): 4d correct mongo-init path

### DIFF
--- a/.github/workflows/ansible-prod-cloud.yml
+++ b/.github/workflows/ansible-prod-cloud.yml
@@ -98,11 +98,13 @@ jobs:
         run: |
           # Issue #223 scope: verify ansible deployed the app dir + mongo-init scripts.
           # Actual user seeding (requires prod secrets via prod-deploy.yml) is verified in issue #224.
+          # mongo-init path matches the compose mount (./infra/mongodb-init) and
+          # the prod-deploy.yml tar-over-ssh copy target ($PROD_DEPLOY_DIR/infra/mongodb-init).
           ssh -o BatchMode=yes root@smokecloud-2 "
             set -e
             test -f /opt/smart-smoker-prod/cloud.docker-compose.yml \
               && echo 'PASS: compose file present'
-            test -f /opt/smart-smoker-prod/mongo-init/01-create-users.js \
+            test -f /opt/smart-smoker-prod/infra/mongodb-init/01-create-users.js \
               && echo 'PASS: mongo-init script present'
           "
 


### PR DESCRIPTION
## Summary

4d checked `/opt/smart-smoker-prod/mongo-init/` but the real path is `/opt/smart-smoker-prod/infra/mongodb-init/` — matching the compose mount (`./infra/mongodb-init:/docker-entrypoint-initdb.d`) and prod-deploy.yml's tar-over-ssh copy target.

## Current verify status (last run)

| Check | Status |
|-------|--------|
| 4a SSH+Tailscale | ✅ |
| 4b Docker+compose | ✅ |
| 4c Mongo localhost bind | ✅ |
| 4d files (compose ✅ / mongo-init path) | ⚙️ this PR fixes path |
| 4e Backup timer | ❌ needs `run_ansible=true` |
| 4f Funnel | ✅ |

## 4e still requires ansible apply

`backup-mongodb.timer` is inactive — the `backups` role has never run on `smokecloud-2`. This is a real provisioning gap (issue #223 AC: "Automated backups configured"). Fix by triggering with `run_ansible=true`.

## Test plan

- [ ] Merge → trigger `run_ansible=true` → applies backups role (4e) + confirms files (4d)