### PR TITLE
fix(ci): pass mongo_app_password to ansible + production env gate

### DIFF
--- a/.github/workflows/ansible-prod-cloud.yml
+++ b/.github/workflows/ansible-prod-cloud.yml
@@ -27,6 +27,9 @@ jobs:
   ansible-and-verify:
     name: Ansible apply + verify smokecloud-2
     runs-on: [self-hosted, linux, proxmox]
+    # production environment holds prod-scoped secrets (MONGO_APP_PASSWORD etc.)
+    # and provides the manual-approval gate for prod config changes.
+    environment: production
     timeout-minutes: 30
 
     steps:
@@ -52,14 +55,18 @@ jobs:
       - name: Run ansible-playbook setup-prod-cloud.yml
         if: ${{ inputs.run_ansible }}
         working-directory: infra/proxmox/ansible
+        env:
+          # backups role templates the mongodb backup script with this credential.
+          MONGO_APP_PASSWORD: ${{ secrets.MONGO_APP_PASSWORD }}
+          TS_AUTH_KEY: ${{ inputs.tailscale_auth_key }}
         run: |
-          EXTRA_VARS=""
-          if [ -n "${{ inputs.tailscale_auth_key }}" ]; then
-            EXTRA_VARS="tailscale_auth_key=${{ inputs.tailscale_auth_key }}"
+          EXTRA_ARGS=(--extra-vars "mongo_app_password=${MONGO_APP_PASSWORD}")
+          if [ -n "${TS_AUTH_KEY}" ]; then
+            EXTRA_ARGS+=(--extra-vars "tailscale_auth_key=${TS_AUTH_KEY}")
           fi
           ansible-playbook playbooks/setup-prod-cloud.yml \
             --limit prod_cloud \
-            ${EXTRA_VARS:+--extra-vars "$EXTRA_VARS"} \
+            "${EXTRA_ARGS[@]}" \
             -v
 
       # ── Verification ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The `run_ansible=true` apply failed with `AnsibleUndefinedVariable: 'mongo_app_password' is undefined`. The `backups` role templates the mongodb backup script (`backup-mongodb.sh.j2`) with `{{ mongo_app_password }}` — a secret that was never passed.

Fixes:
- **`environment: production`** on the job — this is where `MONGO_APP_PASSWORD` lives (per PRD #216) and it adds the manual-approval gate that's appropriate for any prod config change.
- Pass `mongo_app_password` as an `--extra-vars` sourced from the secret.
- Secrets routed through `env:` + a bash array so they never land in `ps`-visible argv via word-splitting.

## What the last apply already accomplished (ok=49 changed=8)

The ansible run got most of the way before the backups task — docker, dns-guard, ufw, fail2ban, tailscale all converged. Only the backups role (the 4e gap) failed on the missing secret. This PR unblocks it.

## Note: production gate now applies to ALL runs

Adding `environment: production` means even verify-only runs require approval. That's intentional — this workflow only ever touches the prod box. Approve each run in the Actions UI.

## Test plan

- [ ] Merge → trigger `run_ansible=true` → approve gate → backups role applies → 4e (backup timer) passes
- [ ] All 6 checks green