### PR TITLE
Closes #250: setup-prod-cloud.yml tailscale role fails mid-apply (ansible manages tailscale over its own tailscale SSH)

### DIFF
--- a/infra/proxmox/ansible/inventory/hosts.yml
+++ b/infra/proxmox/ansible/inventory/hosts.yml
@@ -23,7 +23,13 @@ all:
         prod_cloud:
           hosts:
             smart-smoker-cloud-prod:
-              ansible_host: smokecloud-2  # Tailscale hostname (100.92.43.59)
+              # Connect over the direct bridge IP, not the Tailscale MagicDNS name
+              # (smokecloud-2 / 100.92.43.59). The tailscale role is the last role in
+              # setup-prod-cloud.yml; managing tailscale over its own SSH session severs
+              # the control connection mid-play and the apply reports failed=1 (issue #250).
+              # The self-hosted proxmox runner is on the 10.20.0.0/24 bridge, so the direct
+              # IP is reachable. Mirrors the virtual-smoker direct-IP provisioning pattern.
+              ansible_host: 10.20.0.30  # Direct bridge IP (Tailscale name: smokecloud-2)
               ansible_user: root
               ansible_python_interpreter: /usr/bin/python3
               environment: prod


### PR DESCRIPTION
## Summary

The tailscale role is the last role in `setup-prod-cloud.yml`. When ansible reaches `smokecloud-2` over its Tailscale MagicDNS name, managing the local tailscale state severs the SSH-over-tailscale control session mid-play and the apply reports `failed=1` (no clean `fatal:` — a connection-drop signature). This PR connects prod_cloud over the direct bridge IP (`10.20.0.30`) instead, so the tailscale role no longer manages the interface ansible is connected through. The self-hosted proxmox runner is on the `10.20.0.0/24` bridge, so the direct IP is reachable. Mirrors the virtual-smoker direct-IP provisioning pattern. The `tailscale_hostname` host var (`smokecloud-2`) is unchanged; only the ansible control connection moves to the direct IP. No other hosts affected.

## Closes

Closes #250 — setup-prod-cloud.yml tailscale role fails mid-apply (ansible manages tailscale over its own tailscale SSH)

## Smoke

`smoke: SKIPPED — infra-only ansible inventory change; smoke harness targets running app services (backend/frontend/device), none deployed locally; inventory YAML validated`

## Manual verification

- [ ] `ansible-prod-cloud.yml` with `run_ansible=true` completes the **apply** job green against `smokecloud-2`
- [ ] `setup-prod-cloud.yml` `PLAY RECAP` shows `failed=0`
- [ ] No regression to dev-cloud / virtual-smoker provisioning
- [ ] Verify job still passes all 6 checks afterward

## ⚠️ HITL — detailed steps (human required)

Three of the four acceptance criteria cannot be verified by CI on this PR alone — the apply runs against the real `smokecloud-2` box behind the `production` environment gate. A human must execute the following after merge (or against this branch via workflow_dispatch):

### Step 1 — Trigger the gated apply

1. Go to **Actions → ansible-prod-cloud** (`.github/workflows/ansible-prod-cloud.yml`).
2. Click **Run workflow**, select branch (`master` after merge, or `feat/issue-250` to pre-verify).
3. Set input `run_ansible=true`. Run it.
4. The **apply** job pauses on the `production` environment gate — click **Review deployments → approve** to release it.

### Step 2 — Watch the apply job

1. Open the apply job log. Confirm ansible connects to `10.20.0.30` (not `smokecloud-2` / `100.92.43.59`) — visible in the early `Gathering Facts` / connection lines.
2. Confirm the play reaches and completes `TASK [tailscale : ...]` tasks **without** the connection dropping (previous failure point: `TASK [tailscale : Check if Tailscale is already connected]`).
3. Confirm `PLAY RECAP` shows `failed=0` for `smart-smoker-cloud-prod`. Job must finish green.

### Step 3 — Run the verify job

1. The ungated **verify** job runs in the same workflow after apply (it SSHes to `smokecloud-2` over tailscale independently).
2. Confirm all **6 verify checks** pass (same checks that were authoritative for #223).

### Step 4 — Regression spot-check (dev-cloud / virtual-smoker)

1. No inventory lines for `dev_cloud`, `github-runner`, or `virtual-smoker` changed in this PR (diff is prod_cloud only) — review diff to confirm.
2. Optionally re-run the dev-cloud / virtual-smoker provisioning workflows (or wait for their next scheduled/normal run) and confirm they stay green.

### Step 5 — Close out

1. If all green: tick the four checkboxes above in this PR; done.
2. If apply still fails in the tailscale role: capture the run URL + `PLAY RECAP`, reopen #250 with the log excerpt (fallback options 2/3 from the issue: guard/skip tailscale role on connected hosts, or async+reconnect).

---

Generated by `/team-pickup` at 2026-06-09T20:22:52-04:00
