### PR TITLE
Closes #253: modernize tailscale serve/funnel CLI in tailscale role (+idempotency guard)

### DIFF
--- a/infra/proxmox/ansible/roles/tailscale/tasks/funnel.yml
+++ b/infra/proxmox/ansible/roles/tailscale/tasks/funnel.yml
@@ -1,28 +1,62 @@
 ---
 # Configure Tailscale Funnel for public internet access
 
-- name: Verify Tailscale Serve is configured before enabling Funnel
-  ansible.builtin.command: tailscale serve status
-  register: tailscale_serve_check
+- name: Check current Tailscale Serve/Funnel configuration
+  ansible.builtin.command: tailscale serve status --json
+  register: tailscale_funnel_status_check
   changed_when: false
-  failed_when: tailscale_serve_check.rc != 0
+  failed_when: false
 
-- name: Configure Tailscale Serve for Funnel ports
+- name: Parse live Tailscale Funnel configuration
+  ansible.builtin.set_fact:
+    tailscale_funnel_live: >-
+      {{ (tailscale_funnel_status_check.stdout | from_json)
+         if tailscale_funnel_status_check.rc == 0
+            and tailscale_funnel_status_check.stdout | length > 0
+         else {} }}
+
+# Idempotency guard: only treat the host as already configured when every
+# desired public port is present in the live AllowFunnel map with value true.
+# A surprising JSON shape collapses to an empty map -> not configured -> we
+# re-run `funnel --bg` (safe to repeat), avoiding a false skip that would
+# leave a fresh box unconfigured.
+- name: Determine whether desired Funnel ports are already live
+  ansible.builtin.set_fact:
+    tailscale_funnel_already_configured: >-
+      {{ tailscale_funnel_config
+         | rejectattr('port', 'in', tailscale_funnel_live_ports)
+         | list | length == 0 }}
+  vars:
+    tailscale_funnel_allow_map: "{{ tailscale_funnel_live.AllowFunnel | default({}) }}"
+    tailscale_funnel_live_ports: >-
+      {{ tailscale_funnel_allow_map
+         | dict2items
+         | selectattr('value', 'equalto', true)
+         | map(attribute='key')
+         | map('regex_replace', '^.*:(\d+)$', '\1')
+         | map('int')
+         | list }}
+
+- name: Report Tailscale Funnel idempotency decision
+  ansible.builtin.debug:
+    msg: >-
+      Tailscale Funnel desired ports
+      {{ tailscale_funnel_config | map(attribute='port') | list }}
+      already configured: {{ tailscale_funnel_already_configured }}
+
+# Modern CLI (tailscale >= 1.50): `funnel --bg` enables the funnel and implies
+# the matching serve proxy, so no separate `serve` step is needed. Port 443 is
+# the implicit default; other ports require --https=PORT.
+- name: Enable Tailscale Funnel for each configured port
   ansible.builtin.command: >-
-    tailscale serve
-    https:{{ item.port }}
-    /
+    tailscale funnel --bg
+    {% if item.port != 443 %}--https={{ item.port }} {% endif %}
     {{ item.target_port }}
   loop: "{{ tailscale_funnel_config }}"
-  register: tailscale_funnel_serve_result
-  changed_when: tailscale_funnel_serve_result.rc == 0
-
-- name: Enable Tailscale Funnel for each configured port
-  ansible.builtin.command: tailscale funnel {{ item.port }} on
-  loop: "{{ tailscale_funnel_config }}"
   register: tailscale_funnel_result
-  changed_when: "'Funnel started' in tailscale_funnel_result.stdout or tailscale_funnel_result.rc == 0"
+  changed_when: tailscale_funnel_result.rc == 0
   failed_when: tailscale_funnel_result.rc != 0
+  when: not tailscale_funnel_already_configured
 
 - name: Create Tailscale Funnel configuration script
   ansible.builtin.template:

--- a/infra/proxmox/ansible/roles/tailscale/templates/tailscale-funnel.sh.j2
+++ b/infra/proxmox/ansible/roles/tailscale/templates/tailscale-funnel.sh.j2
@@ -12,18 +12,13 @@ echo "Resetting existing Tailscale Serve/Funnel configuration..."
 tailscale serve reset || true
 
 {% if tailscale_funnel_config | length > 0 %}
-# Configure Serve endpoints for Funnel
-echo "Configuring Tailscale Serve endpoints..."
-{% for endpoint in tailscale_funnel_config %}
-echo "  - Setting up HTTPS:{{ endpoint.port }} -> localhost:{{ endpoint.target_port }}"
-tailscale serve https:{{ endpoint.port }} / {{ endpoint.target_port }}
-{% endfor %}
-
-# Enable Funnel for each port
+# Enable Funnel for each port (modern CLI, tailscale >= 1.50).
+# `funnel --bg` implies the matching serve proxy, so no separate serve step is
+# needed. Port 443 is the implicit default; other ports need --https=PORT.
 echo "Enabling Tailscale Funnel for public access..."
 {% for endpoint in tailscale_funnel_config %}
-echo "  - Enabling Funnel on port {{ endpoint.port }}"
-tailscale funnel {{ endpoint.port }} on
+echo "  - Enabling Funnel on HTTPS:{{ endpoint.port }} -> localhost:{{ endpoint.target_port }}"
+tailscale funnel --bg {% if endpoint.port != 443 %}--https={{ endpoint.port }} {% endif %}{{ endpoint.target_port }}
 {% endfor %}
 {% else %}
 echo "No Funnel endpoints configured."

--- a/infra/proxmox/ansible/tests/test-tailscale-role.yml
+++ b/infra/proxmox/ansible/tests/test-tailscale-role.yml
@@ -235,6 +235,31 @@
         that: true
         success_msg: "Funnel script template renders to valid bash"
 
+    # Test 14b: Modern Tailscale CLI syntax (tailscale >= 1.50)
+    # The pre-1.50 `serve https:PORT / TARGET` and `funnel PORT on` forms were
+    # removed in 1.96.x and cause apply to fail. Assert the rendered script uses
+    # the current --bg syntax.
+    - name: Read rendered funnel script
+      ansible.builtin.slurp:
+        src: /tmp/test-tailscale-funnel.sh
+      register: rendered_funnel_script
+
+    - name: Decode rendered funnel script
+      ansible.builtin.set_fact:
+        rendered_funnel_content: "{{ rendered_funnel_script.content | b64decode }}"
+
+    - name: Assert template uses modern Tailscale serve/funnel CLI
+      ansible.builtin.assert:
+        that:
+          # No legacy serve form: `serve https:PORT / TARGET`
+          - "'serve https:' not in rendered_funnel_content"
+          # No legacy funnel toggle form: `funnel PORT on`
+          - not (rendered_funnel_content | regex_search('funnel\\s+[0-9]+\\s+on'))
+          # Modern background serve/funnel
+          - "'--bg' in rendered_funnel_content"
+        fail_msg: "Rendered funnel script still uses pre-1.50 Tailscale CLI syntax"
+        success_msg: "Funnel script uses modern Tailscale CLI (--bg) syntax"
+
     # Test 15: File Permissions Template
     - name: Test - Verify template sets correct permissions
       ansible.builtin.shell: |


### PR DESCRIPTION
## Summary

`setup-prod-cloud.yml` apply was failing at `TASK [tailscale : Configure Tailscale Serve for Funnel ports]` because `roles/tailscale/tasks/funnel.yml` used the pre-1.50 serve/funnel CLI (`tailscale serve https:443 / 80`, `tailscale funnel 443 on`), which tailscale 1.96.4 on `smokecloud-2` rejects. This PR (1) adds an idempotency guard that parses `tailscale serve status --json` and skips reconfiguration when every desired funnel port (443, 8443) is already funnel-enabled — empty or unparseable JSON falls through to reconfigure, never a false skip; (2) replaces the legacy commands with modern `tailscale funnel --bg [--https=PORT] TARGET` (funnel implies serve in tailscale ≥ 1.50), dropping the separate legacy serve task; (3) applies the same modernization to `templates/tailscale-funnel.sh.j2` and adds test 14b asserting the rendered helper script uses `--bg` with no legacy syntax. Verified locally: ansible-lint (production profile) passes; `--syntax-check` rc=0 on setup-prod-cloud / setup-virtual-smoker / setup-dev-cloud; serve.yml (virtual-smoker path) untouched.

## Closes

Closes #253 — tailscale role funnel.yml uses legacy serve/funnel CLI — apply fails on tailscale 1.96.x

## Smoke

`smoke: SKIPPED — infra-only ansible change; app services (backend:3001/frontend:3000/device:3003) not running locally. Grounded gate: changed YAML files parse clean, funnel.sh.j2 template intact.`

## Manual verification

- [ ] `ansible-prod-cloud.yml` with `run_ansible=true` apply job green against `smokecloud-2`; `PLAY RECAP` shows `failed=0` (HITL: production gate)
- [ ] Re-running apply is idempotent: funnel tasks report `ok`/`skipped`, not `changed`, when config already live (HITL)
- [ ] Funnel still serving after apply: `https://smokecloud-2.tail74646.ts.net` and `:8443` reachable; verify job 6/6 (HITL)
- [ ] No regression to virtual-smoker (uses `tailscale_serve_*` path of the same role) — local: ansible-lint + role syntax check pass ✅ (done pre-merge)

## ⚠️ HITL — detailed steps (human required)

The first three acceptance criteria run against the real `smokecloud-2` box behind the `production` environment gate. Execute after merge:

### Step 1 — Trigger the gated apply (first run: proves failed=0)

1. Go to **Actions → Ansible Prod Cloud** (`.github/workflows/ansible-prod-cloud.yml`).
2. **Run workflow** on `master`, input `run_ansible=true`.
3. Approve the `production` environment gate (**Review deployments → approve**). Note the 5-minute wait timer after approval.

### Step 2 — Check the apply log (use RAW log, not `gh run view --log`)

`gh run view --log` silently truncates after long verbose lines — it swallowed the real failure twice before (#250, #253). Use the raw log:

```bash
gh api repos/benjr70/Smart-Smoker-V2/actions/jobs/<apply_job_id>/logs > /tmp/apply.log
grep -E 'TASK \[tailscale|fatal:|failed:|PLAY RECAP|failed=' /tmp/apply.log
```

Confirm:
1. `TASK [tailscale : Configure Tailscale Serve for Funnel ports]` is **gone** (replaced by the new guard + `Enable Tailscale Funnel` tasks).
2. The funnel tasks report `ok`/`skipped` (config already live on smokecloud-2) — no `failed:` items.
3. `PLAY RECAP` shows `failed=0`.

### Step 3 — Idempotency run (second apply, proves AC2)

1. Re-run the same workflow (`run_ansible=true`, approve gate again).
2. In the raw log, confirm funnel tasks report `ok`/`skipped` and **not** `changed`, and `PLAY RECAP` shows `changed=0` (or at minimum no funnel task in the changed set), `failed=0`.

### Step 4 — Funnel still serving (proves AC3)

1. The verify job in the same run must pass **6/6** checks.
2. Spot-check from any tailnet or public machine:
   ```bash
   curl -sI https://smokecloud-2.tail74646.ts.net | head -1
   curl -sI https://smokecloud-2.tail74646.ts.net:8443 | head -1
   ```
   Both should return an HTTP status line (200/301/etc.), not connection errors.

### Step 5 — Close out

1. All green: tick the checkboxes above; #253 fully validated; the prod ansible apply path is green end-to-end for the first time.
2. If the funnel tasks fail with a new CLI error: capture the raw-log excerpt, reopen #253 with it. The old box config is untouched by a failed run (guard skips before any mutation when config is live).

---

Generated by `/team-pickup` at 2026-06-09T21:15:14-04:00
