### PR TITLE
fix(ci): release.yml publish-smoker needs prebuild:true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,11 @@ jobs:
       ref: ${{ needs.set-version.outputs.ref }}
       mode: 'release'
       platforms: 'linux/amd64,linux/arm/v7'
+      # publish.yml's publish job downloads fresh source (publish-workspace) with
+      # no dist/ — the smoker/device-service/electron Dockerfiles COPY prebuilt
+      # dist, so publish must build it first. nightly.yml already passes this;
+      # the release path silently defaulted to false and broke on v1.6.0.
+      prebuild: true
     secrets: inherit
 
   # Deploy to smoker devices (optional; Watchtower will also update :latest)


### PR DESCRIPTION
## Summary

First release since the workflow refactor (v1.6.0) failed all three `publish-smoker` jobs with `"/apps/smoker/dist": not found`. Root cause: `publish.yml`'s publish job downloads the `publish-workspace` artifact (fresh source, no `dist/`); the smoker/device-service/electron Dockerfiles `COPY` prebuilt dist, which only exists when the caller passes `prebuild: true`. `nightly.yml` passes it; `release.yml` silently defaulted to `false`. The `build-smoker` job's output lives in the separate `build-workspace` artifact namespace and never reaches publish — `prebuild` is the supported path.

Evidence: rerun of failed jobs reproduced identically with no concurrent runs (rules out cache race).

## Refs

Refs #224 (surfaced during pre-cutover verification runbook execution) — needed for #225 (cutover wants release-tagged smoker images baked to `smokecloud`).

## After merge

Re-publish v1.6.0 smoker images from master's fixed workflow:

```bash
gh workflow run release.yml --ref master -f version=1.6.0 -f deploy_smoker=false
```

(`deploy_smoker=false` — no `Smoker` runner registered; image publish is all we need pre-cutover.)

## Smoke

`smoke: SKIPPED — CI workflow config only, no app code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)