### PR TITLE
docs+fix: as-executed cutover runbook (#225) + working migrate-prod-data.sh (#257)

### DIFF
--- a/docs/Infrastructure/guides/prod-cutover.md
+++ b/docs/Infrastructure/guides/prod-cutover.md
@@ -1,0 +1,211 @@
+# Production Cutover Runbook (Issue #225)
+
+**Human-in-the-loop** procedure that cut production from the legacy box to the
+new Proxmox box, migrated the live data once, and (pending soak) retires the
+legacy deploy path. PRD #216 "Cutover sequence" steps 3–5.
+
+> This is the **as-executed** record of the 2026-06-16 cutover, corrected from
+> the original plan. The two biggest surprises vs the plan are called out inline
+> — read them before reusing this for any future box move.
+
+## Topology (as found at cutover)
+
+| Box | Tailnet name (after) | SSH | Mongo | App DB | Notes |
+| --- | --- | --- | --- | --- | --- |
+| **New prod** | `smokecloud` (was `smokecloud-2`) | `root@smokecloud` | `mongo:7.0`, **auth** (`admin` / `MONGO_ROOT_PASSWORD` in `/opt/smart-smoker-prod/.env`), bound `127.0.0.1` | **`smartsmoker`** | LXC VMID **104** (`smart-smoker-cloud-prod`) on Proxmox `192.168.1.151`, bridge IP `10.20.0.30`, app v1.6.0 |
+| **Legacy** | `smokecloud-legacy` (was `smokecloud`) | `ubuntu@smokecloud-legacy` | `mongo:4.4`, **no auth**, bound `0.0.0.0` | **`test`** | app v1.5.x, the only copy of real prod data pre-backup |
+
+> ⚠️ **Surprise 1 — DB name changed.** The v1.5 app wrote to mongo's default
+> `test` db; v1.6 uses `smartsmoker`. Migration must **cross-rename**
+> `test.*` → `smartsmoker.*` (`mongorestore --nsFrom 'test.*' --nsTo 'smartsmoker.*'`).
+>
+> ⚠️ **Surprise 2 — `scripts/migrate-prod-data.sh` does NOT work here.** It
+> defaults `--db smart-smoker`, passes no mongo auth, runs host-level
+> `mongodump`/`mongorestore` (tools live only inside the containers), and can't
+> cross-rename. The migration below was done **manually** with the corrected
+> mechanic. Fixing the script is tracked as a follow-up issue.
+
+All commands below run from an ops host on the tailnet with an SSH key
+authorized as `root@` on the new box and `ubuntu@` on legacy.
+
+---
+
+## Step 0 — Recover the new box if tailscale is down
+
+The new LXC stayed up on Proxmox but `tailscaled` dropped (its node-key
+expired), so it showed offline in the tailnet. You don't need the tailnet name
+to get in — go through Proxmox:
+
+```bash
+ssh root@192.168.1.151      # Proxmox hypervisor
+pct enter 104               # into the prod LXC as root (no password)
+```
+
+Inside the container:
+
+```bash
+systemctl restart tailscaled
+tailscale status            # if "Logged out", it prints a login URL
+# open the printed https://login.tailscale.com/a/... URL in a browser to re-auth
+tailscale status            # confirm the node is back, name + 100.92.43.59
+```
+
+> Do **not** run tailscale's suggested `tailscale up --hostname=smokecloud` here
+> — that prematurely starts the name swap and, while legacy still owns
+> `smokecloud`, tailscale would dedup the node. The name swap is Step 3, done in
+> the admin console.
+
+Verify the app before proceeding:
+
+```bash
+ssh root@smokecloud-2 'docker ps --format "{{.Names}}\t{{.Image}}\t{{.Status}}"'  # v1.6.0, all healthy
+ssh root@smokecloud-2 'cd /opt/smart-smoker-prod && bash scripts/deployment-health-check.sh localhost 3'
+ssh root@smokecloud-2 "ss -tlnp | grep -E '27017|3001|:80 '"   # all 127.0.0.1 (hardening #219)
+```
+
+---
+
+## Step 1 — Back up legacy `test` (rollback net — do FIRST)
+
+Legacy held the only copy of real prod data. Take a verified off-box backup
+before anything. `mongodump` is **read-only** on the source.
+
+```bash
+mkdir -p ./backups; TS=$(date +%Y%m%d-%H%M%S)
+# copy #1 — stream legacy 'test' to the ops host
+ssh ubuntu@smokecloud-legacy 'docker exec mongo mongodump --db test --archive --gzip' \
+  > ./backups/legacy-test-$TS.archive.gz
+gunzip -t ./backups/legacy-test-$TS.archive.gz && ls -lh ./backups/legacy-test-$TS.archive.gz
+# copy #2 — stash on the new box too
+ssh root@smokecloud-2 'mkdir -p /opt/smart-smoker-prod/backups'
+scp ./backups/legacy-test-$TS.archive.gz root@smokecloud-2:/opt/smart-smoker-prod/backups/
+```
+
+Prove the archive actually restores — into a **throwaway** db, touching neither
+legacy nor `smartsmoker`:
+
+```bash
+ssh root@smokecloud-2 "set -a; . /opt/smart-smoker-prod/.env; set +a
+  docker cp /opt/smart-smoker-prod/backups/legacy-test-$TS.archive.gz mongo:/tmp/v.gz
+  docker exec mongo mongorestore -u admin -p \"\$MONGO_ROOT_PASSWORD\" --authenticationDatabase admin \
+    --archive=/tmp/v.gz --gzip --nsFrom 'test.*' --nsTo 'backup_verify.*'
+  docker exec mongo mongosh -u admin -p \"\$MONGO_ROOT_PASSWORD\" --authenticationDatabase admin --quiet \
+    --eval 'var s=db.getSiblingDB(\"backup_verify\"); s.getCollectionNames().forEach(c=>print(c+\": \"+s.getCollection(c).countDocuments()))'
+  docker exec mongo mongosh -u admin -p \"\$MONGO_ROOT_PASSWORD\" --authenticationDatabase admin --quiet \
+    --eval 'db.getSiblingDB(\"backup_verify\").dropDatabase()'
+  docker exec mongo rm -f /tmp/v.gz"
+```
+
+✅ Gate: gzip valid, two copies, throwaway restore counts == source.
+
+---
+
+## Step 2 — Freeze, migrate once, verify
+
+Downtime starts at the freeze and ends at the Step 3 name swap (~2 min). Pick a
+low-traffic moment.
+
+```bash
+# 1. freeze legacy writes (stop app; mongo stays up for the dump)
+ssh ubuntu@smokecloud-legacy 'docker stop backend_cloud frontend_cloud'
+
+# 2. migrate: dump legacy 'test' | restore --drop into new 'smartsmoker' (auth + cross-rename)
+ssh ubuntu@smokecloud-legacy 'docker exec mongo mongodump --db test --archive --gzip' \
+| ssh root@smokecloud-2 'set -a; . /opt/smart-smoker-prod/.env; set +a;
+    docker exec -i mongo mongorestore -u admin -p "$MONGO_ROOT_PASSWORD" \
+      --authenticationDatabase admin --archive --gzip --drop \
+      --nsFrom "test.*" --nsTo "smartsmoker.*"'
+```
+
+`--drop` replaces only the new box's seed collections; legacy is never written.
+
+```bash
+# 3. verify counts on new box == legacy
+ssh root@smokecloud-2 'set -a; . /opt/smart-smoker-prod/.env; set +a;
+  docker exec mongo mongosh -u admin -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet \
+    --eval "var s=db.getSiblingDB(\"smartsmoker\"); s.getCollectionNames().sort().forEach(c=>print(c+\": \"+s.getCollection(c).countDocuments()))"'
+
+# 4. restart new backend so mongoose re-applies schema indexes (the dump carried only _id)
+ssh root@smokecloud-2 'docker restart backend_cloud'
+```
+
+✅ Gate (2026-06-16 actual): temps 68231, smokes 18, presmokes 18, postsmokes
+19, ratings 16, smokeprofiles 16, states/settings/notificationsettings 1,
+notificationsubscriptions 0. 68,321 docs total, 0 failed.
+
+> VAPID continuity: legacy had `notificationsubscriptions: 0`, so no web-push
+> subs to break. If a future box has subs, confirm the new box's
+> `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` match legacy before exposing it.
+
+---
+
+## Step 3 — Move the `smokecloud` name + Funnel (Tailscale admin console)
+
+In <https://login.tailscale.com/admin/machines>:
+
+1. Rename legacy node `smokecloud` → `smokecloud-legacy`.
+2. Rename new node `smokecloud-2` → `smokecloud`.
+
+Then re-assert Funnel on the new box (target by IP to dodge DNS-propagation lag;
+a fresh TLS cert auto-provisions for the new name):
+
+```bash
+ssh root@100.92.43.59 'tailscale serve reset; tailscale funnel --bg 80; tailscale funnel --bg --https=8443 3001; tailscale serve status'
+```
+
+✅ Gate: `tailscale status` shows `smokecloud` = new box; `serve status` lists
+both funnel endpoints.
+
+---
+
+## Step 4 — Verify on the public name
+
+```bash
+curl -k -s -o /dev/null -w '%{http_code}\n' https://smokecloud.tail74646.ts.net/      # 200
+curl -k -s https://smokecloud.tail74646.ts.net:8443/api/health                         # {"status":"ok","database":{"name":"smartsmoker",...}}
+curl -k -s https://smokecloud.tail74646.ts.net:8443/api/history | head -c 200          # real migrated cooks
+```
+
+Human spot-check at `https://smokecloud.tail74646.ts.net`: login, past cooks
+list populated, open a cook → temp graph renders, settings load.
+
+> `/api/smoke/current` returns 500 — **not a bug**: there is no such route, so
+> "current" hits `@Get('/:id')` and fails the ObjectId cast. The frontend never
+> calls it. Ignore.
+
+The Playwright smoke (`scripts/smoke`) checks API + browser; the API checks pass
+anywhere, but the browser leg needs a host where Playwright's chromium installs
+(it does **not** on ubuntu 26.04). Live user traffic is the de-facto e2e pass.
+
+---
+
+## Step 5 — Hold legacy as fallback
+
+- Keep `smokecloud-legacy` powered, mongo up, app containers **stopped**. Data
+  intact, no divergent writes.
+- **Rollback** = admin-console rename `smokecloud` back to the legacy node, then
+  `ssh ubuntu@smokecloud-legacy 'docker start backend_cloud frontend_cloud'`.
+- Soak 1–2 weeks before Step 6.
+
+---
+
+## Step 6 — Retire the legacy deploy path (after soak)
+
+Normal PR, gated on a clean soak:
+
+- Delete `.github/workflows/cloud-deploy.yml`.
+- Remove its references in `.github/workflows/deploy-version.yml`,
+  `.github/workflows/nightly.yml`, `.github/actionlint.yaml`.
+- Deregister the `SmokeCloud` self-hosted runner (GitHub → Settings → Actions →
+  Runners) and uninstall its service on the legacy box.
+- Only `prod-deploy.yml` (proxmox-runner) deploys prod afterward.
+- Close #225.
+
+## Rollback playbook
+
+| Symptom | Action |
+| --- | --- |
+| Migration fails mid-stream | Guard not relevant (manual); fix connectivity; re-run the Step 2 pipe. Legacy untouched. |
+| New box unhealthy after name swap | Rename `smokecloud` back to legacy node, `docker start` its containers. |
+| Public URL 404/timeout | `ssh root@smokecloud 'tailscale serve status'`; re-run the three funnel commands. |
+| Data looks wrong on new box | Re-restore the Step 1 archive into `smartsmoker` (`--drop`), or roll the name back and triage offline. |

--- a/docs/Infrastructure/guides/prod-cutover.md
+++ b/docs/Infrastructure/guides/prod-cutover.md
@@ -19,11 +19,18 @@ legacy deploy path. PRD #216 "Cutover sequence" steps 3–5.
 > `test` db; v1.6 uses `smartsmoker`. Migration must **cross-rename**
 > `test.*` → `smartsmoker.*` (`mongorestore --nsFrom 'test.*' --nsTo 'smartsmoker.*'`).
 >
-> ⚠️ **Surprise 2 — `scripts/migrate-prod-data.sh` does NOT work here.** It
-> defaults `--db smart-smoker`, passes no mongo auth, runs host-level
-> `mongodump`/`mongorestore` (tools live only inside the containers), and can't
-> cross-rename. The migration below was done **manually** with the corrected
-> mechanic. Fixing the script is tracked as a follow-up issue.
+> ⚠️ **Surprise 2 — the original `scripts/migrate-prod-data.sh` did NOT work
+> here.** It defaulted `--db smart-smoker`, passed no mongo auth, ran host-level
+> `mongodump`/`mongorestore` (tools live only inside the containers), and
+> couldn't cross-rename. The 2026-06-16 migration was therefore done **manually**
+> with the corrected mechanic (Step 2). The script has since been **rewritten**
+> (#257) to do exactly that — docker-exec, auth sourced from the box env file,
+> and namespace cross-rename — so the codified path now matches reality:
+>
+> ```bash
+> scripts/migrate-prod-data.sh smokecloud-legacy smokecloud \
+>   --old-user ubuntu --src-db test --dst-db smartsmoker
+> ```
 
 All commands below run from an ops host on the tailnet with an SSH key
 authorized as `root@` on the new box and `ubuntu@` on legacy.

--- a/scripts/migrate-prod-data.sh
+++ b/scripts/migrate-prod-data.sh
@@ -1,26 +1,48 @@
 #!/usr/bin/env bash
 # migrate-prod-data.sh — one-time guarded MongoDB data migration (deep module)
 #
-# Dumps from old prod via SSH and restores into new prod via SSH. The dump is
+# Dumps from the OLD prod mongo and restores into the NEW prod mongo. The dump is
 # streamed directly into the restore (mongodump --archive | mongorestore
 # --archive) so no intermediate dump file ever touches disk on the operator's
 # machine.
+#
+# Real-env shape (learned during the #225 cutover — see
+# docs/Infrastructure/guides/prod-cutover.md and #257):
+#   - mongo runs INSIDE a container on each box, so the tools are invoked via
+#     `docker exec <container> mongodump|mongorestore`, NOT on the host.
+#   - the app DB NAME CHANGED between versions (old `test` → new `smartsmoker`),
+#     so the restore cross-renames namespaces (--nsFrom/--nsTo).
+#   - the NEW box mongo requires AUTH; credentials are sourced from an env file
+#     ON the new box (never hardcoded, never passed on the command line from
+#     here). The OLD box mongo is assumed auth-less (legacy 4.4).
 #
 # A run-once guard (sentinel file beside this script) prevents accidental
 # re-execution: once a migration has completed, subsequent invocations are
 # no-ops. This makes the script safe to wire into an automated cutover step
 # that might be retried.
 #
-# All remote work runs over `ssh root@<host>`, so SSH is the single system
+# All remote work runs over `ssh <user>@<host>`, so SSH is the single system
 # boundary (mockable in tests by PATH-prepending an `ssh` stub).
 #
 # Usage:
-#   scripts/migrate-prod-data.sh <old-host> <new-host> [--db <dbname>]
+#   scripts/migrate-prod-data.sh <old-host> <new-host> [options]
 #
-# Parameters:
-#   old-host   SSH host of old prod (mongodump source), SSH'd as root@<host>.
-#   new-host   SSH host of new prod (mongorestore target), SSH'd as root@<host>.
-#   --db <n>   Database name (default: smart-smoker).
+# Options:
+#   --src-db NAME          Source database (default: test)
+#   --dst-db NAME          Target database (default: smartsmoker)
+#   --old-user USER        SSH user for old host (default: root)
+#   --new-user USER        SSH user for new host (default: root)
+#   --old-container NAME   Mongo container name on old host (default: mongo)
+#   --new-container NAME   Mongo container name on new host (default: mongo)
+#   --new-env-file PATH    Env file on new host holding the mongo password
+#                          (default: /opt/smart-smoker-prod/.env)
+#   --new-mongo-user USER  Target auth user (default: admin)
+#   --new-pass-var NAME    Env var (in --new-env-file) holding the target
+#                          password (default: MONGO_ROOT_PASSWORD)
+#
+# Example (the actual #225 cutover):
+#   scripts/migrate-prod-data.sh smokecloud-legacy smokecloud \
+#     --old-user ubuntu --src-db test --dst-db smartsmoker
 #
 # Exit codes:
 #   0  migration completed (or already run — guard active)
@@ -32,7 +54,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GUARD_FILE="${SCRIPT_DIR}/.migrate-prod-data.done"
 
 usage() {
-    echo "Usage: $(basename "$0") <old-host> <new-host> [--db <dbname>]" >&2
+    echo "Usage: $(basename "$0") <old-host> <new-host> [options]" >&2
+    echo "  --src-db --dst-db --old-user --new-user --old-container" >&2
+    echo "  --new-container --new-env-file --new-mongo-user --new-pass-var" >&2
 }
 
 #-------------------------------------------------------------------------------
@@ -40,7 +64,16 @@ usage() {
 #-------------------------------------------------------------------------------
 OLD_HOST="${1:-}"
 NEW_HOST="${2:-}"
-DB_NAME="smart-smoker"
+
+SRC_DB="test"
+DST_DB="smartsmoker"
+OLD_USER="root"
+NEW_USER="root"
+OLD_CONTAINER="mongo"
+NEW_CONTAINER="mongo"
+NEW_ENV_FILE="/opt/smart-smoker-prod/.env"
+NEW_MONGO_USER="admin"
+NEW_PASS_VAR="MONGO_ROOT_PASSWORD"
 
 if [ -z "${OLD_HOST}" ] || [ -z "${NEW_HOST}" ]; then
     echo "migrate-prod-data: missing required <old-host> and/or <new-host>" >&2
@@ -49,17 +82,27 @@ if [ -z "${OLD_HOST}" ] || [ -z "${NEW_HOST}" ]; then
 fi
 
 shift 2 || true
+
+# Generic "flag requires a value" reader.
+require_val() {
+    if [ -z "${2:-}" ]; then
+        echo "migrate-prod-data: $1 requires a value" >&2
+        usage
+        exit 1
+    fi
+}
+
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --db)
-            DB_NAME="${2:-}"
-            if [ -z "${DB_NAME}" ]; then
-                echo "migrate-prod-data: --db requires a value" >&2
-                usage
-                exit 1
-            fi
-            shift 2
-            ;;
+        --src-db)         require_val "$1" "${2:-}"; SRC_DB="$2"; shift 2 ;;
+        --dst-db)         require_val "$1" "${2:-}"; DST_DB="$2"; shift 2 ;;
+        --old-user)       require_val "$1" "${2:-}"; OLD_USER="$2"; shift 2 ;;
+        --new-user)       require_val "$1" "${2:-}"; NEW_USER="$2"; shift 2 ;;
+        --old-container)  require_val "$1" "${2:-}"; OLD_CONTAINER="$2"; shift 2 ;;
+        --new-container)  require_val "$1" "${2:-}"; NEW_CONTAINER="$2"; shift 2 ;;
+        --new-env-file)   require_val "$1" "${2:-}"; NEW_ENV_FILE="$2"; shift 2 ;;
+        --new-mongo-user) require_val "$1" "${2:-}"; NEW_MONGO_USER="$2"; shift 2 ;;
+        --new-pass-var)   require_val "$1" "${2:-}"; NEW_PASS_VAR="$2"; shift 2 ;;
         *)
             echo "migrate-prod-data: unknown argument '$1'" >&2
             usage
@@ -77,17 +120,30 @@ if [ -f "${GUARD_FILE}" ]; then
 fi
 
 #-------------------------------------------------------------------------------
-# Dump from old prod, restore into new prod (streamed).
+# Build the remote commands.
 #
-# mongorestore --drop ensures the target collections are replaced rather than
-# merged, giving a clean cutover. The pipeline status is checked via
-# PIPESTATUS so a failure on either side fails the migration without creating
-# the guard (allowing a retry).
+# Source: legacy mongo (auth-less) — plain `docker exec ... mongodump`.
+# Target: new mongo (auth) — source the password from the box env file inside
+#   the ssh session (so it is never visible to this process or its args), then
+#   `docker exec -i ... mongorestore` with auth, --drop, and namespace rename.
+#
+# The `\$${NEW_PASS_VAR}` keeps the password expansion on the REMOTE side, after
+# the env file is sourced — nothing sensitive is interpolated locally.
 #-------------------------------------------------------------------------------
-echo "migrate-prod-data: migrating db '${DB_NAME}' from ${OLD_HOST} -> ${NEW_HOST}"
+DUMP_CMD="docker exec ${OLD_CONTAINER} mongodump --db '${SRC_DB}' --archive --gzip"
 
-ssh "root@${OLD_HOST}" "mongodump --db '${DB_NAME}' --archive" \
-    | ssh "root@${NEW_HOST}" "mongorestore --archive --drop --db '${DB_NAME}'"
+RESTORE_CMD="set -a; . '${NEW_ENV_FILE}'; set +a; \
+docker exec -i ${NEW_CONTAINER} mongorestore \
+--username '${NEW_MONGO_USER}' --password \"\$${NEW_PASS_VAR}\" \
+--authenticationDatabase admin \
+--archive --gzip --drop \
+--nsFrom '${SRC_DB}.*' --nsTo '${DST_DB}.*'"
+
+echo "migrate-prod-data: migrating '${SRC_DB}' on ${OLD_USER}@${OLD_HOST}" \
+     "-> '${DST_DB}' on ${NEW_USER}@${NEW_HOST}"
+
+ssh "${OLD_USER}@${OLD_HOST}" "${DUMP_CMD}" \
+    | ssh "${NEW_USER}@${NEW_HOST}" "${RESTORE_CMD}"
 
 # shellcheck disable=SC2206
 PIPE_STATUS=("${PIPESTATUS[@]}")

--- a/scripts/migrate-prod-data.test.sh
+++ b/scripts/migrate-prod-data.test.sh
@@ -3,9 +3,11 @@
 #
 # Run: bash scripts/migrate-prod-data.test.sh
 #
-# Strategy: migrate-prod-data.sh performs all remote work over `ssh root@<host>`.
+# Strategy: migrate-prod-data.sh performs all remote work over `ssh <user>@<host>`.
 # We mock `ssh` by prepending a temp dir to PATH. The mock `ssh` appends each
-# invocation to a call log so tests can assert on ordering and content.
+# invocation to a call log so tests can assert on ordering and content (the
+# remote command is passed as a single ssh argument, so it lands in the log
+# verbatim — docker-exec, auth flags, namespace rename and all).
 #
 # The run-once guard is a sentinel file at ${SCRIPT_DIR}/.migrate-prod-data.done.
 # To keep tests hermetic we point the script at an isolated SCRIPT_DIR by copying
@@ -72,12 +74,26 @@ make_isolated_script() {
     echo "${iso_dir}"
 }
 
+# Assert the call log contains a literal substring; fail the named test if not.
+assert_contains() {
+    local log="$1" needle="$2" name="$3"
+    if ! grep -qF -e "${needle}" "${log}"; then
+        fail "${name}" "expected to find: ${needle}
+calls:
+$(cat "${log}")"
+        return 1
+    fi
+    return 0
+}
+
 #-------------------------------------------------------------------------------
-# Test 1: first run (guard absent) invokes ssh twice (mongodump source +
-#         mongorestore target) and creates the guard file afterward (AC 1).
+# Test 1: first run (guard absent) dumps from old via docker-exec mongodump,
+#         restores into new via docker-exec mongorestore WITH AUTH, --drop, and
+#         a namespace cross-rename, sourcing creds from the new box env file —
+#         then creates the guard. Defaults: src-db=test, dst-db=smartsmoker.
 #-------------------------------------------------------------------------------
 test_first_run_success() {
-    echo "TEST: first run dumps then restores and creates guard"
+    echo "TEST: first run docker-exec dump|restore (auth + cross-rename) + guard"
 
     local tmpdir call_log mock_dir iso_dir iso_script
     tmpdir="$(mktemp -d)"
@@ -90,7 +106,7 @@ test_first_run_success() {
 
     export SSH_CALL_LOG="${call_log}"
     PATH="${mock_dir}:${PATH}" \
-        bash "${iso_script}" oldprod newprod --db smart-smoker >/dev/null 2>&1
+        bash "${iso_script}" oldprod newprod >/dev/null 2>&1
     local exit_code=$?
 
     if [ "${exit_code}" -ne 0 ]; then
@@ -99,49 +115,42 @@ $(cat "${call_log}")"
         return
     fi
 
-    local calls
-    calls="$(cat "${call_log}")"
-
     # Exactly two ssh calls: dump from old, restore into new.
     local ssh_count
     ssh_count="$(grep -c '^ssh ' "${call_log}")"
     if [ "${ssh_count}" -ne 2 ]; then
         fail "first run must issue exactly 2 ssh calls" "got ${ssh_count}; calls:
-${calls}"
+$(cat "${call_log}")"
         return
     fi
 
-    # Dump targets old host with mongodump; restore targets new host with mongorestore.
-    if ! grep -qF "root@oldprod" "${call_log}" || ! grep -qF "mongodump" "${call_log}"; then
-        fail "must mongodump from root@oldprod" "calls:
-${calls}"
-        return
-    fi
-    if ! grep -qF "root@newprod" "${call_log}" || ! grep -qF "mongorestore" "${call_log}"; then
-        fail "must mongorestore into root@newprod" "calls:
-${calls}"
-        return
-    fi
+    local n="first run mechanic"
+    # Source: ssh to old host, mongodump INSIDE the container, default src-db.
+    assert_contains "${call_log}" "ssh root@oldprod" "${n}" || return
+    assert_contains "${call_log}" "docker exec mongo mongodump --db 'test' --archive --gzip" "${n}" || return
 
-    # Database name must appear in the remote commands.
-    if ! grep -qF "smart-smoker" "${call_log}"; then
-        fail "remote commands must reference the db name" "calls:
-${calls}"
-        return
-    fi
+    # Target: ssh to new host, sources the box env file, mongorestore via
+    # docker exec -i with auth, --drop, and the namespace cross-rename.
+    assert_contains "${call_log}" "ssh root@newprod" "${n}" || return
+    assert_contains "${call_log}" ". '/opt/smart-smoker-prod/.env'" "${n}" || return
+    assert_contains "${call_log}" "docker exec -i mongo mongorestore" "${n}" || return
+    assert_contains "${call_log}" "--username 'admin'" "${n}" || return
+    assert_contains "${call_log}" "MONGO_ROOT_PASSWORD" "${n}" || return
+    assert_contains "${call_log}" "--authenticationDatabase admin" "${n}" || return
+    assert_contains "${call_log}" "--drop" "${n}" || return
+    assert_contains "${call_log}" "--nsFrom 'test.*' --nsTo 'smartsmoker.*'" "${n}" || return
 
     # Guard file must exist after a successful run.
     if [ ! -f "${iso_dir}/.migrate-prod-data.done" ]; then
-        fail "guard file must be created after a successful migration" "calls:
-${calls}"
+        fail "guard file must be created after a successful migration"
         return
     fi
 
-    pass "first run dumps then restores and creates guard"
+    pass "first run docker-exec dump|restore (auth + cross-rename) + guard"
 }
 
 #-------------------------------------------------------------------------------
-# Test 2: second run (guard present) exits 0 and issues NO ssh calls (AC 2).
+# Test 2: second run (guard present) exits 0 and issues NO ssh calls.
 #-------------------------------------------------------------------------------
 test_guard_blocks_second_run() {
     echo "TEST: existing guard blocks a second run"
@@ -160,7 +169,7 @@ test_guard_blocks_second_run() {
 
     export SSH_CALL_LOG="${call_log}"
     PATH="${mock_dir}:${PATH}" \
-        bash "${iso_script}" oldprod newprod --db smart-smoker >/dev/null 2>&1
+        bash "${iso_script}" oldprod newprod >/dev/null 2>&1
     local exit_code=$?
 
     if [ "${exit_code}" -ne 0 ]; then
@@ -178,6 +187,77 @@ $(cat "${call_log}")"
 }
 
 #-------------------------------------------------------------------------------
+# Test 3: custom options (--old-user, --src-db, --dst-db, --new-container) are
+#         threaded into the remote commands.
+#-------------------------------------------------------------------------------
+test_custom_options() {
+    echo "TEST: custom user/db/container options reflected in remote commands"
+
+    local tmpdir call_log mock_dir iso_dir iso_script
+    tmpdir="$(mktemp -d)"
+    call_log="${tmpdir}/ssh-calls.log"
+    touch "${call_log}"
+    mock_dir="$(make_mock_bin)"
+    iso_dir="$(make_isolated_script)"
+    iso_script="${iso_dir}/migrate-prod-data.sh"
+    trap "rm -rf '${tmpdir}' '${mock_dir}' '${iso_dir}'" RETURN
+
+    export SSH_CALL_LOG="${call_log}"
+    PATH="${mock_dir}:${PATH}" \
+        bash "${iso_script}" smokecloud-legacy smokecloud \
+            --old-user ubuntu --src-db olddb --dst-db newdb \
+            --new-container mongo7 >/dev/null 2>&1
+    local exit_code=$?
+
+    if [ "${exit_code}" -ne 0 ]; then
+        fail "custom-options run should exit 0" "got exit code ${exit_code}"
+        return
+    fi
+
+    local n="custom options"
+    assert_contains "${call_log}" "ssh ubuntu@smokecloud-legacy" "${n}" || return
+    assert_contains "${call_log}" "mongodump --db 'olddb'" "${n}" || return
+    assert_contains "${call_log}" "ssh root@smokecloud" "${n}" || return
+    assert_contains "${call_log}" "docker exec -i mongo7 mongorestore" "${n}" || return
+    assert_contains "${call_log}" "--nsFrom 'olddb.*' --nsTo 'newdb.*'" "${n}" || return
+
+    pass "custom user/db/container options reflected in remote commands"
+}
+
+#-------------------------------------------------------------------------------
+# Test 4: missing required hosts → usage error, exit 1, no ssh calls.
+#-------------------------------------------------------------------------------
+test_missing_args() {
+    echo "TEST: missing hosts exits 1 with no ssh calls"
+
+    local tmpdir call_log mock_dir iso_dir iso_script
+    tmpdir="$(mktemp -d)"
+    call_log="${tmpdir}/ssh-calls.log"
+    touch "${call_log}"
+    mock_dir="$(make_mock_bin)"
+    iso_dir="$(make_isolated_script)"
+    iso_script="${iso_dir}/migrate-prod-data.sh"
+    trap "rm -rf '${tmpdir}' '${mock_dir}' '${iso_dir}'" RETURN
+
+    export SSH_CALL_LOG="${call_log}"
+    PATH="${mock_dir}:${PATH}" \
+        bash "${iso_script}" oldprod >/dev/null 2>&1
+    local exit_code=$?
+
+    if [ "${exit_code}" -ne 1 ]; then
+        fail "missing new-host must exit 1" "got exit code ${exit_code}"
+        return
+    fi
+    if [ -s "${call_log}" ]; then
+        fail "missing-arg run must issue NO ssh calls" "got calls:
+$(cat "${call_log}")"
+        return
+    fi
+
+    pass "missing hosts exits 1 with no ssh calls"
+}
+
+#-------------------------------------------------------------------------------
 # Run suite
 #-------------------------------------------------------------------------------
 echo "=========================================="
@@ -186,6 +266,8 @@ echo "=========================================="
 
 test_first_run_success
 test_guard_blocks_second_run
+test_custom_options
+test_missing_args
 
 echo ""
 echo "=========================================="


### PR DESCRIPTION
## Summary

Two things from the 2026-06-16 production cutover:

1. **As-executed cutover runbook** (`docs/Infrastructure/guides/prod-cutover.md`) — records what actually happened, replacing the pre-cutover plan's assumptions.
2. **Fix `migrate-prod-data.sh`** so the codified migration path matches reality (was previously only mock-tested and unusable against the real boxes).

## The two surprises (driving both changes)
- **App DB name changed v1.5→v1.6**: legacy used mongo's default `test` db; v1.6 uses `smartsmoker`. Migration must cross-rename `test.*` → `smartsmoker.*`.
- **Original `migrate-prod-data.sh` didn't work**: defaulted `--db smart-smoker`, no mongo auth, host-level `mongodump`/`mongorestore` (tools live only inside the containers), no cross-rename.

## Script rewrite (#257)
- `docker exec mongodump|mongorestore` (tools run inside the containers)
- separate `--src-db`/`--dst-db` + namespace cross-rename (`--nsFrom`/`--nsTo`)
- target mongo **auth**, password sourced from the box env file **inside** the ssh session (never interpolated locally / never on the command line)
- configurable users / containers / env-file / auth-user via flags
- keeps the streamed (no intermediate disk) design + run-once guard
- tests rewritten to assert the real invocation (docker-exec, auth flags, `--drop`, `--nsFrom`/`--nsTo`) + custom-option threading + missing-arg handling — **4/4 pass**

```
$ bash scripts/migrate-prod-data.sh smokecloud-legacy smokecloud \
    --old-user ubuntu --src-db test --dst-db smartsmoker
```

## Closes / related
- Closes #257 — migrate-prod-data.sh unusable against real prod env
- #225 — cutover (executed; stays open until legacy `cloud-deploy.yml` + `SmokeCloud` runner retired after soak)

## Verification
- `bash scripts/migrate-prod-data.test.sh` → Ran 4 | Failed 0.
- Cutover itself verified live: `/api/health` ok (db `smartsmoker`), `/api/history` serves migrated cooks, real user UI session confirmed, migration counts equal (68,321 docs).
- Note: prod-data backups live untracked in `backups/` on the ops VM; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)