### PR TITLE
fix(ci): retry SSH connectivity in dev-deploy (transient tailnet drop)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -91,12 +91,25 @@ jobs:
       - name: Verify SSH connectivity
         run: |
           echo "Testing SSH connectivity to ${DEV_HOST}..."
-          if ! ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o PasswordAuthentication=no root@${DEV_HOST} "echo 'SSH connection successful'"; then
-            echo "SSH connection failed. Capturing verbose output for diagnostics..."
-            ssh -vvv -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o PasswordAuthentication=no root@${DEV_HOST} "echo 'test'" 2>&1 || true
-            exit 1
-          fi
-          echo "SSH connectivity verified"
+          # The dev-cloud LXC can briefly drop off the tailnet (tailscaled
+          # restart / node-key refresh), so a single attempt yields spurious
+          # deploy failures. Retry with backoff before giving up.
+          ATTEMPTS=5
+          DELAY=15
+          for i in $(seq 1 "${ATTEMPTS}"); do
+            if ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o PasswordAuthentication=no root@${DEV_HOST} "echo 'SSH connection successful'"; then
+              echo "SSH connectivity verified (attempt ${i}/${ATTEMPTS})"
+              exit 0
+            fi
+            echo "Attempt ${i}/${ATTEMPTS} failed to reach ${DEV_HOST}."
+            if [ "${i}" -lt "${ATTEMPTS}" ]; then
+              echo "Retrying in ${DELAY}s..."
+              sleep "${DELAY}"
+            fi
+          done
+          echo "SSH connection failed after ${ATTEMPTS} attempts. Capturing verbose output for diagnostics..."
+          ssh -vvv -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o PasswordAuthentication=no root@${DEV_HOST} "echo 'test'" 2>&1 || true
+          exit 1
 
       - name: URL-encode MongoDB password
         id: encode_password


### PR DESCRIPTION
## Problem

Dev Deploy run [27656359052](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/27656359052/job/81791799015) failed at **Verify SSH connectivity**:

```
ssh: connect to host smoker-dev-cloud-1 port 22: Connection timed out
debug1: Connecting to smoker-dev-cloud-1 [100.106.216.34] port 22.
debug1: connect to address 100.106.216.34 port 22: Connection timed out
```

The hostname resolved fine (tailnet IP `100.106.216.34`); the box itself was briefly unreachable. Minutes later it was reachable again (port 22 open, ping 0.7ms). The dev-cloud LXC periodically drops off the tailnet for a short window (tailscaled restart / node-key refresh) — the same class of blip seen on the prod box during the #225 cutover.

**Not caused by the PR #258 merge** — that diff (docs + `migrate-prod-data.sh`) doesn't touch dev SSH; the master merge merely *triggered* nightly → dev-deploy during the outage window.

## Fix

The connectivity step did a **single** attempt and failed the whole deploy on the first timeout. Retry **5× with a 15s backoff** (~2 min grace) before giving up, so a transient drop self-heals. Verbose `ssh -vvv` diagnostics are still captured on final failure.

## Verification

- `dev-deploy.yml` is valid YAML.
- Logic: returns success + exits 0 on the first reachable attempt; only `exit 1` after all 5 fail.
- The already-failed run can simply be re-run now that the box is back.

## Note

`prod-deploy.yml` health/deploy already has its own retry/rollback; this change is scoped to the dev-deploy connectivity probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)