### PR TITLE
fix(ci): install terraform in drift workflow (runner lacks it on PATH)

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -36,6 +36,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Terraform
+        # Self-hosted proxmox runner lacks unzip and passwordless sudo, so
+        # hashicorp/setup-terraform@v3 cannot extract its release zip. Install
+        # terraform manually using python's stdlib zipfile module instead
+        # (python3 is already required by the ansible workflows on this runner).
+        run: |
+          if command -v terraform >/dev/null 2>&1; then
+            echo "terraform already present: $(terraform version | head -n1)"
+            exit 0
+          fi
+          TF_VERSION=1.5.7
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64) TF_ARCH=amd64 ;;
+            aarch64|arm64) TF_ARCH=arm64 ;;
+            armv7l) TF_ARCH=arm ;;
+            *) echo "::error::Unsupported arch $ARCH" ; exit 1 ;;
+          esac
+          TMP=$(mktemp -d)
+          curl -fsSL "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TF_ARCH}.zip" -o "$TMP/tf.zip"
+          python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$TMP/tf.zip" "$TMP"
+          chmod +x "$TMP/terraform"
+          mkdir -p "$HOME/.local/bin"
+          mv "$TMP/terraform" "$HOME/.local/bin/terraform"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/terraform" version
+
       - name: Terraform Init
         run: terraform init -input=false
 


### PR DESCRIPTION
## Problem

Nightly **Terraform Drift** job fails at **Terraform Init**:

```
terraform: command not found
##[error]Process completed with exit code 127.
```

([failing run](https://github.com/benjr70/Smart-Smoker-V2/actions/runs/27662912820))

The `[self-hosted, linux, proxmox]` runner no longer ships `terraform` on `PATH`. Unlike `terraform-plan.yml` and `infra-provision-vm.yml`, `terraform-drift.yml` had **no self-install step** — it assumed terraform was pre-installed, so it dies at Init every night.

## Fix

Add a **Setup Terraform** step (between Checkout and Init), copied verbatim from `terraform-plan.yml`:
- pinned `1.5.7`, arch detection
- python-stdlib `zipfile` extraction (runner lacks `unzip` + passwordless `sudo`)
- binary into `$HOME/.local/bin` via `$GITHUB_PATH`
- idempotency guard (`command -v terraform`)

Keeps all three terraform workflows consistent.

## Out of scope
- Node 20 deprecation warning on `actions/checkout@v4` (cosmetic, separate).
- Baking terraform into the runner image permanently (infra change).

## Verification
- YAML validated locally (`yaml.safe_load`).
- Post-merge: trigger via `workflow_dispatch` and confirm run reaches **Terraform Plan (drift check)** instead of exit 127 at Init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)