### PR TITLE
fix(ci): install terraform/ansible on self-hosted runner in provision workflows

### DIFF
--- a/.github/workflows/ansible-provision.yml
+++ b/.github/workflows/ansible-provision.yml
@@ -98,7 +98,12 @@ jobs:
 
       - name: Install Ansible dependencies
         run: |
-          pip install --user ansible
+          # `pip install --user` lands in ~/.local/bin, which is not on the
+          # self-hosted runner's PATH — add it so ansible-galaxy/ansible-playbook
+          # resolve in this and later steps (exit 127 otherwise).
+          python3 -m pip install --user ansible
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           ansible-galaxy collection install community.general ansible.posix --force
 
       - name: Run Ansible playbook
@@ -162,7 +167,12 @@ jobs:
 
       - name: Install Ansible dependencies
         run: |
-          pip install --user ansible
+          # `pip install --user` lands in ~/.local/bin, which is not on the
+          # self-hosted runner's PATH — add it so ansible-galaxy/ansible-playbook
+          # resolve in this and later steps (exit 127 otherwise).
+          python3 -m pip install --user ansible
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           ansible-galaxy collection install community.general ansible.posix --force
 
       - name: Run Ansible playbook

--- a/.github/workflows/infra-provision-vm.yml
+++ b/.github/workflows/infra-provision-vm.yml
@@ -41,12 +41,29 @@ jobs:
 
       - name: Ensure Terraform installed
         run: |
-          if ! command -v terraform &>/dev/null; then
-            TFVER=$(curl -sL https://checkpoint-api.hashicorp.com/v1/check/terraform | python3 -c "import sys,json; print(json.load(sys.stdin)['current_version'])")
-            curl -sLo /tmp/tf.zip "https://releases.hashicorp.com/terraform/${TFVER}/terraform_${TFVER}_linux_amd64.zip"
-            sudo unzip -o /tmp/tf.zip -d /usr/local/bin/ && rm /tmp/tf.zip
+          if command -v terraform >/dev/null 2>&1; then
+            echo "terraform already present: $(terraform version | head -n1)"
+            exit 0
           fi
-          terraform version
+          # Self-hosted runner has no terraform on PATH and may lack sudo/unzip,
+          # so install to $HOME/.local/bin and extract with python (matches the
+          # proven snippet in terraform-drift.yml / terraform-plan.yml).
+          TF_VERSION=1.5.7
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64) TF_ARCH=amd64 ;;
+            aarch64|arm64) TF_ARCH=arm64 ;;
+            armv7l) TF_ARCH=arm ;;
+            *) echo "::error::Unsupported arch $ARCH" ; exit 1 ;;
+          esac
+          TMP=$(mktemp -d)
+          curl -fsSL "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TF_ARCH}.zip" -o "$TMP/tf.zip"
+          python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$TMP/tf.zip" "$TMP"
+          chmod +x "$TMP/terraform"
+          mkdir -p "$HOME/.local/bin"
+          mv "$TMP/terraform" "$HOME/.local/bin/terraform"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/terraform" version
 
       - name: Terraform Init
         working-directory: infra/proxmox/terraform


### PR DESCRIPTION
## Problem

Both Layer-0 **provisioning** jobs went red on merge #262 (fired because the PR touched \`infra/\`), each exit 127:

- **Provision Virtual Smoker VM** → \`terraform: command not found\` (`infra-provision-vm.yml`). Install step used \`sudo unzip\` + checkpoint-api latest-version lookup — breaks when the self-hosted runner lacks \`sudo\`/\`unzip\` or the API returns empty.
- **Ansible Provision** → \`ansible-galaxy: command not found\` (`ansible-provision.yml`, provision-dev + provision-prod). \`pip install --user\` lands in \`~/.local/bin\` (not on PATH) and galaxy ran in the same step.

These are unrelated to the #262 hostname rename — pure runner-tooling gaps (same class as #260/#261).

## Fix

- **Terraform:** replace the brittle install with the proven snippet from \`terraform-drift.yml\` (#261) — pinned \`1.5.7\`, arch-aware, python-zip extract, install to \`$HOME/.local/bin\` via \`$GITHUB_PATH\`.
- **Ansible:** add \`~/.local/bin\` to \`$GITHUB_PATH\` (+ \`export PATH\` for the current step) and use \`python3 -m pip\`, matching the already-correct pattern in \`infra-provision-vm.yml\`'s ansible job.

## Verification

- Both workflows parse as valid YAML.
- Install logic mirrors the snippet already proven green in \`terraform-drift.yml\` / \`infra-provision-vm.yml\`.
- Real validation lands when these run on master after merge.

> Note: this only fixes the *tooling* gap. Hardening the provisioning design (prod TF gating + remote state backend) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)