### PR TITLE
fix(infra): correct github-runner tailnet name (smoker-runner → github-runner)

### DIFF
--- a/docs/Infrastructure/features/networking/tailscale.md
+++ b/docs/Infrastructure/features/networking/tailscale.md
@@ -81,7 +81,7 @@ ansible-playbook playbooks/verify-tailscale.yml
 Visit https://login.tailscale.com/admin/machines
 
 You should now see these machines:
-- ✅ `smoker-runner` (github-runner)
+- ✅ `github-runner` (GitHub Actions runner)
 - ✅ `smoker-dev-cloud` (dev environment)
 - ✅ `smokecloud` (production environment)
 

--- a/infra/proxmox/ansible/README.md
+++ b/infra/proxmox/ansible/README.md
@@ -163,7 +163,7 @@ All infrastructure is connected via Tailscale VPN, creating a secure mesh networ
 
 ```
 Tailscale Mesh Network
-├─ smoker-runner (GitHub Actions runner)
+├─ github-runner (GitHub Actions runner)
 │  └─ Tags: runner, ci-cd
 ├─ smart-smoker-dev-cloud (Development environment)
 │  ├─ Tags: server, development
@@ -301,7 +301,7 @@ tailscale funnel status  # Production only
 
 ```bash
 # From any machine on the Tailscale network
-ping smoker-runner
+ping github-runner
 ping smart-smoker-dev-cloud
 ping smokecloud
 ping virtual-smoker

--- a/infra/proxmox/ansible/inventory/host_vars/github-runner.yml
+++ b/infra/proxmox/ansible/inventory/host_vars/github-runner.yml
@@ -21,7 +21,9 @@ additional_packages:
   - dnsutils
 
 # Tailscale Configuration
-tailscale_hostname: "smoker-runner"
+# Must match the inventory ansible_host and the real tailnet peer name so the
+# tailscale role does not rename the node back to a name CI can't resolve.
+tailscale_hostname: "github-runner"
 tailscale_tags:
   - tag:runner
   - tag:ci-cd

--- a/infra/proxmox/ansible/inventory/hosts.yml
+++ b/infra/proxmox/ansible/inventory/hosts.yml
@@ -4,7 +4,12 @@ all:
     runners:
       hosts:
         github-runner:
-          ansible_host: smoker-runner  # Tailscale hostname (100.105.61.87)
+          # Tailscale MagicDNS name (100.89.29.127). The peer re-registered under
+          # its node name `github-runner` after a tailnet re-auth; the old
+          # `smoker-runner` name no longer resolves and made Ansible Provision
+          # fail UNREACHABLE on the first task. Keep this in sync with the actual
+          # tailnet peer name (same drift class fixed for dev-cloud in #262).
+          ansible_host: github-runner
           ansible_user: root
           ansible_python_interpreter: /usr/bin/python3
 

--- a/infra/proxmox/ansible/tests/QA-REPORT.md
+++ b/infra/proxmox/ansible/tests/QA-REPORT.md
@@ -136,11 +136,11 @@ All required variables are defined with appropriate defaults.
 
 Each of the 4 environments has been validated for correct Tailscale configuration.
 
-#### GitHub Runner (smoker-runner) ✅
+#### GitHub Runner (github-runner) ✅
 
 | Configuration | Expected | Actual | Status |
 |--------------|----------|--------|--------|
-| Hostname | smoker-runner | smoker-runner | ✅ PASS |
+| Hostname | github-runner | github-runner | ✅ PASS |
 | Tags | tag:runner, tag:ci-cd | ✅ Configured | ✅ PASS |
 | Serve Enabled | No | No | ✅ PASS |
 | Funnel Enabled | No | No | ✅ PASS |

--- a/infra/proxmox/ansible/tests/README.md
+++ b/infra/proxmox/ansible/tests/README.md
@@ -288,7 +288,7 @@ The security audit validates:
 
 ## Environment-Specific Testing
 
-### GitHub Runner (smoker-runner)
+### GitHub Runner (github-runner)
 - Basic Tailscale connectivity
 - Tags: runner, ci-cd
 - No Serve/Funnel (correct for CI/CD runner)

--- a/infra/proxmox/ansible/tests/TEST-PLAN.md
+++ b/infra/proxmox/ansible/tests/TEST-PLAN.md
@@ -43,7 +43,7 @@ This document outlines the comprehensive testing strategy for validating the Tai
 
 ## Test Environments
 
-### 1. GitHub Runner (smoker-runner)
+### 1. GitHub Runner (github-runner)
 - **Purpose**: CI/CD execution
 - **Tailscale Config**: Basic connectivity, no Serve/Funnel
 - **Tags**: `tag:runner`, `tag:ci-cd`

--- a/infra/proxmox/ansible/tests/run-all-tests.sh
+++ b/infra/proxmox/ansible/tests/run-all-tests.sh
@@ -100,7 +100,7 @@ fi
 print_section "Test Suite 3: Environment Configuration Validation"
 
 echo "3.1 Testing GitHub Runner configuration..."
-if grep -q "tailscale_hostname: \"smoker-runner\"" inventory/host_vars/github-runner.yml && \
+if grep -q "tailscale_hostname: \"github-runner\"" inventory/host_vars/github-runner.yml && \
    grep -q "tag:runner" inventory/host_vars/github-runner.yml; then
   print_pass "GitHub Runner Tailscale config correct"
   ((TOTAL_TESTS++))
@@ -236,7 +236,7 @@ else
 fi
 
 if grep -q "Network Topology" README.md && \
-   grep -q "smoker-runner" README.md && \
+   grep -q "github-runner" README.md && \
    grep -q "smart-smoker-dev-cloud" README.md && \
    grep -q "smokecloud" README.md && \
    grep -q "virtual-smoker" README.md; then

--- a/infra/proxmox/ansible/tests/test-environment-configs.yml
+++ b/infra/proxmox/ansible/tests/test-environment-configs.yml
@@ -25,7 +25,7 @@
     - name: Test - GitHub Runner Tailscale config
       ansible.builtin.assert:
         that:
-          - gh_runner_vars.tailscale_hostname == "smoker-runner"
+          - gh_runner_vars.tailscale_hostname == "github-runner"
           - "'tag:runner' in gh_runner_vars.tailscale_tags"
           - "'tag:ci-cd' in gh_runner_vars.tailscale_tags"
           - gh_runner_vars.tailscale_accept_routes == true
@@ -203,7 +203,7 @@
           - "Environment Configuration Tests Complete!"
           - "=========================================="
           - ""
-          - "GitHub Runner (smoker-runner):"
+          - "GitHub Runner (github-runner):"
           - "  ✓ Basic Tailscale connectivity"
           - "  ✓ Tagged for CI/CD access"
           - "  ✓ No Serve/Funnel (runner doesn't expose services)"

--- a/infra/proxmox/scripts/test-tailscale-mesh.sh
+++ b/infra/proxmox/scripts/test-tailscale-mesh.sh
@@ -13,7 +13,7 @@ NC='\033[0m' # No Color
 
 # Configuration
 HOSTS=(
-  "smoker-runner"
+  "github-runner"
   "smart-smoker-dev-cloud"
   "smokecloud"
   "virtual-smoker"
@@ -118,10 +118,10 @@ test_ssh_connectivity() {
   print_header "Testing SSH Connectivity (Optional)"
 
   print_info "Testing SSH to GitHub runner..."
-  if timeout 5 ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no root@smoker-runner "echo 'SSH OK'" &> /dev/null; then
-    print_success "SSH to smoker-runner works"
+  if timeout 5 ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no root@github-runner "echo 'SSH OK'" &> /dev/null; then
+    print_success "SSH to github-runner works"
   else
-    print_warning "SSH to smoker-runner failed (may require key setup)"
+    print_warning "SSH to github-runner failed (may require key setup)"
   fi
 }
 
@@ -204,7 +204,7 @@ test_virtual_device() {
 check_firewall_rules() {
   print_header "Checking Firewall Rules (on accessible hosts)"
 
-  for host in "smoker-runner" "smart-smoker-dev-cloud" "smokecloud"; do
+  for host in "github-runner" "smart-smoker-dev-cloud" "smokecloud"; do
     print_info "Checking UFW on ${host}..."
 
     if timeout 5 ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no "root@${host}" "ufw status | grep -E '(tailscale0|41641)'" &> /dev/null; then
@@ -238,7 +238,7 @@ generate_summary() {
   echo -e "${GREEN}Tailscale mesh network test completed!${NC}\n"
 
   print_info "Network topology:"
-  print_info "  ├─ smoker-runner (GitHub Actions runner)"
+  print_info "  ├─ github-runner (GitHub Actions runner)"
   print_info "  ├─ smart-smoker-dev-cloud (Development environment)"
   print_info "  ├─ smokecloud (Production environment with Funnel)"
   print_info "  └─ virtual-smoker (Virtual device)"


### PR DESCRIPTION
## Problem

**Ansible Provision** has failed on every master run (months). Root cause is **not** the runner-tooling gap fixed in #263 — that part now works (ansible installs + runs). The play now dies on its very first task:

```
fatal: [github-runner]: UNREACHABLE! ... ssh: Could not resolve hostname smoker-runner: Name or service not known
```

The inventory's `runners` host pointed at `ansible_host: smoker-runner`, but the runner peer **re-registered under its node name `github-runner`** (`100.89.29.127`) after a tailnet re-auth (the same key-expiry/re-login event that drifted dev-cloud). `smoker-runner` no longer resolves → UNREACHABLE.

This is the **same name-drift class fixed for dev-cloud in #262**.

## Fix

- `inventory/hosts.yml`: `ansible_host: smoker-runner` → `github-runner` (matches the real MagicDNS peer name + the host key).
- `inventory/host_vars/github-runner.yml`: `tailscale_hostname` → `github-runner` so the `tailscale` role doesn't rename the node **back** to the unresolvable name on the next provision (prevents re-drift).
- Updated ansible config tests (`test-environment-configs.yml`, `run-all-tests.sh`), the tailscale-mesh script, and docs/QA labels to match.
- **Left untouched:** the `*-runner-1` systemd **service** names and the `smart-smoker-runner-autoregister` **token** name — those are unrelated to the tailnet hostname.

## Scope

Independent of the Terraform Cloud migration (#264) — this alone unblocks **Ansible Provision**. The separate **Provision Virtual Smoker VM** failure (Terraform vars/state) is handled in #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)