### PR TITLE
fix(infra): unpin docker_compose_version (2.24.0 aged out of apt repo)

### DIFF
--- a/infra/proxmox/ansible/inventory/group_vars/all.yml
+++ b/infra/proxmox/ansible/inventory/group_vars/all.yml
@@ -68,7 +68,12 @@ fail2ban_ban_time: 3600    # Ban duration in seconds (1 hour)
 fail2ban_find_time: 600    # Time window to count failures (10 minutes)
 
 # Docker Configuration
-docker_compose_version: "2.24.0"
+# Empty = install the latest docker-compose-plugin from Docker's apt repo. A
+# hard pin (e.g. "2.24.0") breaks provisioning once that exact version ages out
+# of the repo ("no available installation candidate"); the docker role only
+# keeps recent versions. Pin here only to a version you've confirmed is still
+# published, otherwise leave empty. (devices/prod already override to "".)
+docker_compose_version: ""
 docker_users: []
 
 # Node.js Configuration


### PR DESCRIPTION
## Problem

With the runner name (#265) + SSH key now sorted, **Ansible Provision** gets deep into the play (21 tasks OK) then fails in the `docker` role:

```
fatal: [github-runner]: FAILED! => no available installation candidate for docker-compose-plugin=2.24.0
```

`group_vars/all.yml` hard-pinned `docker_compose_version: "2.24.0"`, but Docker's apt repo only retains recent versions and `2.24.0` has aged out. The runner + dev_cloud inherit this; `devices.yml` and prod already override to `""` (latest) — `devices.yml`'s comment even warned that all.yml's pin "may not exist."

## Fix

Set the global default to `""` (install latest `docker-compose-plugin`), with a comment explaining why a hard pin is fragile here. No behavior change for devices/prod (already `""`).

## Context

Part of getting the chronically-failing provisioning workflows green (after #263 runner tooling, #265 runner tailnet name). Next latent failures, if any, are in the `github-runner`/`tailscale` roles which haven't run to completion before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)