### PR TITLE
fix(infra): drop 'runners' from auto dev provisioning (self-provision self-cancels)

### DIFF
--- a/.github/workflows/ansible-provision.yml
+++ b/.github/workflows/ansible-provision.yml
@@ -126,9 +126,14 @@ jobs:
             echo "Running in CHECK MODE - no changes will be made"
           fi
 
-          # Limit to dev hosts only
+          # Limit to dev hosts only. NOTE: 'runners' is intentionally excluded —
+          # this job runs ON the self-hosted runner, and the github-runner role
+          # stops/uninstalls the actions.runner.* service when it deems the
+          # runner "unhealthy", which cancels this very job ("The operation was
+          # canceled"). The runner can only be (re)provisioned safely from a
+          # different machine, so it is managed out-of-band, not here.
           ansible-playbook playbooks/${PLAYBOOK} \
-            --limit 'dev_cloud:devices:runners' \
+            --limit 'dev_cloud:devices' \
             ${EXTRA_ARGS} \
             --extra-vars "github_runner_pat=${{ secrets.RUNNER_PAT }}" \
             --extra-vars "tailscale_auth_key=${{ secrets.TAILSCALE_AUTH_KEY }}" \
@@ -140,7 +145,7 @@ jobs:
         run: |
           echo "Running verification playbook..."
           ansible-playbook playbooks/verify-all.yml \
-            --limit 'dev_cloud:devices:runners' \
+            --limit 'dev_cloud:devices' \
             -v || echo "Verification completed with warnings"
 
       - name: Cleanup SSH key


### PR DESCRIPTION
## Problem

After the runner-name (#265), SSH-key, apt-lock, and docker-compose (#266) fixes, **Ansible Provision** now runs deep into the play (nodejs, ansible, galaxy, terraform, runner user all ✅) then dies with:

```
##[error]The operation was canceled.
```

Not a task failure. `provision-dev` runs **on** the self-hosted runner but `--limit` included the `runners` group, so it tried to provision the runner from a job running on that runner. The `github-runner` role, on judging the runner `unhealthy`, runs **"Stop and uninstall stale runner service"** (`systemctl stop actions.runner.*` + `svc.sh uninstall`) — which kills the very job executing it. Self-provisioning is structurally impossible.

## Fix

`provision-dev` (run + verify) limit: `dev_cloud:devices:runners` → `dev_cloud:devices`. The runner is already provisioned and can only be (re)provisioned safely from a different machine, so it's managed out-of-band. `provision-prod` unaffected.

## Context

Last layer in getting the chronically-failing provisioning workflows green: #263 (runner tooling) → #265 (runner tailnet name) → #266 (docker-compose pin) → this. After merge, provision-dev should proceed to the real dev targets (dev_cloud + virtual-smoker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)