### PR TITLE
fix(infra): disable apt sandbox for unprivileged LXC (dev_cloud installs)

### DIFF
--- a/infra/proxmox/ansible/roles/common/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/common/tasks/main.yml
@@ -1,4 +1,18 @@
 ---
+# Disable apt's download sandbox. In an unprivileged LXC the '_apt' user cannot
+# access /var/cache/apt/archives/partial (uid mapping), so package downloads
+# fail with "E: Failed to fetch ... Permission denied" and the install errors
+# out. Running apt as root sidesteps it. Harmless on VMs/privileged containers
+# (apt already effectively runs as root there). Must run before any apt task.
+- name: Disable apt download sandbox (unprivileged LXC compatibility)
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/99-disable-sandbox
+    content: |
+      APT::Sandbox::User "root";
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: true


### PR DESCRIPTION
## Problem

With `runners` dropped (#267), **Ansible Provision** now reaches the real dev target `smart-smoker-dev-cloud` and fails in the `common` role "Install base packages":

```
E: Failed to fetch http://archive.ubuntu.com/.../htop_3.0.5-7build2_amd64.deb
   Could not open file /var/cache/apt/archives/partial/...deb - open (13: Permission denied)
```

`smart-smoker-dev-cloud` is an **unprivileged LXC**. apt's `_apt` sandbox user can't access `/var/cache/apt/archives/partial` (uid mapping), so every package download fails → task errors. (The `W: ... SetupAPTPartialDirectory` lines are the same root cause.)

## Fix

Add a `common`-role task (before any apt task) writing `/etc/apt/apt.conf.d/99-disable-sandbox`:

```
APT::Sandbox::User "root";
```

apt then downloads as root. Harmless on VMs / privileged containers (apt already effectively root there). `devices` (a VM) is unaffected either way.

## Context

Provisioning fix chain: #263 → #265 → #266 → #267 → this. After merge, provision-dev should get through the `common` role on dev_cloud and continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)