### PR TITLE
fix(infra): stop unattended-upgrades before apt (dpkg lock races)

### DIFF
--- a/infra/proxmox/ansible/roles/common/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/common/tasks/main.yml
@@ -13,6 +13,35 @@
     group: root
     mode: "0644"
 
+# Fresh Proxmox templates run unattended-upgrades on boot, which holds
+# /var/lib/dpkg/lock-frontend and makes the provisioning apt tasks fail with
+# "Could not get lock ... held by ... (unattended-upgr)". Stop the auto-update
+# units (timers included so they can't re-trigger mid-play) and wait for any
+# in-flight transaction to release the lock before we touch apt. common runs
+# first in every play, so this guards all later apt tasks (docker, nodejs, ...).
+- name: Stop apt auto-update services during provisioning (avoid dpkg lock races)
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+  loop:
+    - unattended-upgrades.service
+    - apt-daily.service
+    - apt-daily-upgrade.service
+    - apt-daily.timer
+    - apt-daily-upgrade.timer
+  failed_when: false
+  changed_when: false
+
+- name: Wait for the dpkg/apt lock to be released
+  ansible.builtin.shell: |
+    for _ in $(seq 1 60); do
+      fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || exit 0
+      sleep 5
+    done
+    echo "dpkg lock still held after 300s" >&2
+    exit 1
+  changed_when: false
+
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: true


### PR DESCRIPTION
## Problem

Provisioning intermittently dies with:

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process N (unattended-upgr)
```

Fresh Proxmox templates run `unattended-upgrades` on boot, racing the provisioning apt tasks. Hit on the runner (during docker install) and again on `smart-smoker-dev-cloud` (during the nodejs install) — recurs on every host.

## Fix

Two tasks at the top of the `common` role (runs first in every play, so it guards every later apt task — docker, nodejs, …):

1. Stop `unattended-upgrades` + `apt-daily(.upgrade)` services **and timers** (so they can't re-trigger mid-play).
2. Wait up to 300s for any in-flight transaction to release `/var/lib/dpkg/lock-frontend`.

Timers are only **stopped** for the session (still enabled) → automatic security updates resume on reboot.

## Context

Provisioning fix chain: #263 → #265 → #266 → #267 → #268 → this. dev_cloud now clears `common` + `docker`; this unblocks `nodejs` and beyond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)