### PR TITLE
fix(infra): pass mongo_app_password to ansible provisioning

### DIFF
--- a/.github/workflows/ansible-provision.yml
+++ b/.github/workflows/ansible-provision.yml
@@ -137,6 +137,7 @@ jobs:
             ${EXTRA_ARGS} \
             --extra-vars "github_runner_pat=${{ secrets.RUNNER_PAT }}" \
             --extra-vars "tailscale_auth_key=${{ secrets.TAILSCALE_AUTH_KEY }}" \
+            --extra-vars "mongo_app_password=${{ secrets.MONGO_APP_PASSWORD }}" \
             -v
 
       - name: Verify provisioning
@@ -205,6 +206,7 @@ jobs:
             --limit 'prod_cloud' \
             ${EXTRA_ARGS} \
             --extra-vars "github_runner_pat=${{ secrets.RUNNER_PAT }}" \
+            --extra-vars "mongo_app_password=${{ secrets.MONGO_APP_PASSWORD }}" \
             -v
 
       - name: Verify provisioning


### PR DESCRIPTION
## Problem

provision-dev got all the way through `common`, `docker`, `nodejs`, `terraform`, `cloud-app` on `smart-smoker-dev-cloud`, then the `backups` role failed:

```
fatal: [smart-smoker-dev-cloud]: AnsibleUndefinedVariable: 'mongo_app_password' is undefined
```

`roles/backups/defaults/main.yml` sets `backups_mongodb_password: "{{ mongo_app_password }}"`, but the workflow never passed that secret.

## Fix

Add `--extra-vars "mongo_app_password=${{ secrets.MONGO_APP_PASSWORD }}"` to **provision-dev** and **provision-prod** (the `backups` role runs on cloud servers). Secret already exists in the repo. `devices`/virtual-smoker don't run `backups`, so `infra-provision-vm.yml` is unaffected.

## Context

Provisioning fix chain: #263 → #265 → #266 → #267 → #268 → #269 → this. Plus one-time box remediation on dev_cloud (apt partial clean, rsyslog reconfigure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)