### PR TITLE
fix(infra): remove legacy docker.asc apt source (virtual-smoker conflict)

### DIFF
--- a/infra/proxmox/ansible/roles/docker/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/docker/tasks/main.yml
@@ -32,9 +32,10 @@
 # + keyring first so only this role's docker.gpg source remains. Idempotent.
 - name: Remove legacy/conflicting Docker apt source (docker.asc)
   ansible.builtin.shell: |
-    grep -rln 'docker\.asc' /etc/apt/sources.list.d/ /etc/apt/sources.list 2>/dev/null \
-      | xargs -r rm -f
+    files=$(grep -rln 'docker\.asc' /etc/apt/sources.list.d/ /etc/apt/sources.list 2>/dev/null || true)
+    [ -n "$files" ] && rm -f $files
     rm -f /etc/apt/keyrings/docker.asc
+    exit 0
   changed_when: false
 
 - name: Add Docker GPG key

--- a/infra/proxmox/ansible/roles/docker/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/docker/tasks/main.yml
@@ -25,6 +25,18 @@
     state: directory
     mode: '0755'
 
+# A box that previously had Docker installed via the modern docker.asc keyring
+# ends up with two apt sources for the same repo once this role adds its
+# docker.gpg source, and apt refuses to read them: "Conflicting values set for
+# option Signed-By ... docker.asc != docker.gpg". Remove the legacy .asc source
+# + keyring first so only this role's docker.gpg source remains. Idempotent.
+- name: Remove legacy/conflicting Docker apt source (docker.asc)
+  ansible.builtin.shell: |
+    grep -rln 'docker\.asc' /etc/apt/sources.list.d/ /etc/apt/sources.list 2>/dev/null \
+      | xargs -r rm -f
+    rm -f /etc/apt/keyrings/docker.asc
+  changed_when: false
+
 - name: Add Docker GPG key
   ansible.builtin.apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
## Problem

dev_cloud now provisions fully (`failed=0, ok=77`). virtual-smoker fails in the docker role "Add Docker repository":

```
apt_pkg.Error: E:Conflicting values set for option Signed-By regarding source
https://download.docker.com/linux/ubuntu jammy:
/etc/apt/keyrings/docker.asc != /etc/apt/keyrings/docker.gpg
```

The box had a pre-existing Docker apt source using the modern `docker.asc` keyring. Once this role adds its `docker.gpg` source for the **same** repo, apt sees two conflicting `Signed-By` values and refuses to read sources. (`docker.asc` appears nowhere in the repo — it's pre-existing box state.)

## Fix

Idempotent task (before the GPG key/repo tasks) that removes any apt source referencing `docker.asc` plus the `docker.asc` keyring, leaving only this role's `docker.gpg` source. Self-heals affected hosts on next run — no manual VM access needed (the VM's guest agent is off and PVE has no SSH key to it).

## Context

Provisioning fix chain: #263→#265→#266→#267→#268→#269→#270→this. Should be the last layer — dev_cloud green, this clears virtual-smoker's docker step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)