### PR TITLE
fix(infra): clean legacy docker.asc source in common (before any apt task)

### DIFF
--- a/infra/proxmox/ansible/roles/common/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/common/tasks/main.yml
@@ -42,6 +42,20 @@
     exit 1
   changed_when: false
 
+# A host previously set up with Docker via the modern docker.asc keyring ends up
+# with two apt sources for the same repo once the docker role adds its docker.gpg
+# source, and then EVERY apt run (including this cache update) fails with
+# "Conflicting values set for option Signed-By ... docker.asc != docker.gpg".
+# Remove the legacy .asc source/keyring here in common — before any apt task —
+# so apt is readable for the whole play (the docker role re-adds docker.gpg).
+- name: Remove legacy/conflicting Docker apt source (docker.asc)
+  ansible.builtin.shell: |
+    files=$(grep -rln 'docker\.asc' /etc/apt/sources.list.d/ /etc/apt/sources.list 2>/dev/null || true)
+    [ -n "$files" ] && rm -f $files
+    rm -f /etc/apt/keyrings/docker.asc
+    exit 0
+  changed_when: false
+
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: true

--- a/infra/proxmox/ansible/roles/docker/tasks/main.yml
+++ b/infra/proxmox/ansible/roles/docker/tasks/main.yml
@@ -25,19 +25,8 @@
     state: directory
     mode: '0755'
 
-# A box that previously had Docker installed via the modern docker.asc keyring
-# ends up with two apt sources for the same repo once this role adds its
-# docker.gpg source, and apt refuses to read them: "Conflicting values set for
-# option Signed-By ... docker.asc != docker.gpg". Remove the legacy .asc source
-# + keyring first so only this role's docker.gpg source remains. Idempotent.
-- name: Remove legacy/conflicting Docker apt source (docker.asc)
-  ansible.builtin.shell: |
-    files=$(grep -rln 'docker\.asc' /etc/apt/sources.list.d/ /etc/apt/sources.list 2>/dev/null || true)
-    [ -n "$files" ] && rm -f $files
-    rm -f /etc/apt/keyrings/docker.asc
-    exit 0
-  changed_when: false
-
+# Legacy docker.asc apt source is removed in the common role (before any apt
+# task) so the whole play's apt stays readable; nothing to do here.
 - name: Add Docker GPG key
   ansible.builtin.apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
## Problem

The docker.asc/.gpg `Signed-By` conflict breaks **every** apt run. After #271, the affected host (virtual-smoker) now has *both* sources (a prior run added docker.gpg before failing), so provisioning dies even earlier — at the `common` role's `Update apt cache` (`ok=3`), which runs *before* the docker role. So #271's cleanup (in the docker role) never executes.

## Fix

Move the legacy-`docker.asc` cleanup into the **common** role, right before `Update apt cache` (i.e. before any apt task in the play), so apt is readable for the whole run. The docker role re-adds `docker.gpg` as before; its now-redundant cleanup task is removed.

## Context

dev_cloud is fully green (`failed=0`). This unblocks virtual-smoker's very first apt step. Chain: #263→#265→#266→#267→#268→#269→#270→#271→this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)