### PR TITLE
fix(frontend): proxy /socket.io/ to backend for live temps

### DIFF
--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -15,6 +15,21 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Proxy Socket.IO (websocket) to backend for live temp events.
+    # Frontend connects with io('') -> same origin, so the websocket upgrade
+    # must be proxied here. Without this block the upgrade falls through to the
+    # SPA fallback below and returns index.html, breaking live temps.
+    location /socket.io/ {
+        proxy_pass http://backend:3001/socket.io/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Serve static files, fallback to index.html for SPA routing
     location / {
         try_files $uri /index.html;


### PR DESCRIPTION
## Problem
Prod incident: smoker online on Tailscale but **temps not showing in the web app**.

## Diagnosis (live prod)
Pipeline healthy all the way to the browser:
```
Arduino -> device-service(3003) OK -> smoker-app bridge OK -> backend OK -> broadcasting `events` OK (live ~60F probes)
```
Break is the browser websocket. Deployed bundle does `io('')` (because `WS_URL` is unset in every build), so it dials page origin `:443`. But `apps/frontend/nginx.conf` proxied only `/api/` — **no `/socket.io/` block**. The ws upgrade fell through `location /` -> `try_files $uri /index.html`, returning HTML, so socket.io never connected and `events` never reached the browser. Live data existed only on the separate `:8443` Tailscale funnel, which the browser never dials.

Proof:
- `GET /socket.io/?EIO=4&transport=polling` on `:443` -> `<!doctype html>...`
- same on `:8443` -> `0{"sid":"...","upgrades":["websocket"],...}`

The smoker-pi reboot was a red herring — this is static nginx/build config.

## Fix
Add a `/socket.io/` location to the frontend nginx that proxies to `backend:3001` with the `Upgrade`/`Connection` headers required for the websocket handshake. Keeps single-origin (`io('')`) working.

## After merge
Requires a frontend redeploy to prod for temps to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)